### PR TITLE
Disable MacOS in CI to avoid billing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,16 +18,16 @@ jobs:
         run: |
           actonc build
 
-  test-macos:
-    runs-on: macos-12
-    steps:
-      - name: "Check out repository code"
-        uses: actions/checkout@v3
-      - name: "Install acton"
-        run: |
-          wget https://github.com/actonlang/acton/releases/download/tip/acton-darwin-x86_64.tar.bz2
-          tar jxvf $(ls acton-darwin*.tar.bz2 | tail -n1)
-          echo "PATH=$(pwd)/acton/bin:$PATH" >> $GITHUB_ENV
-      - name: "Build"
-        run: |
-          actonc build
+#  test-macos:
+#    runs-on: macos-12
+#    steps:
+#      - name: "Check out repository code"
+#        uses: actions/checkout@v3
+#      - name: "Install acton"
+#        run: |
+#          wget https://github.com/actonlang/acton/releases/download/tip/acton-darwin-x86_64.tar.bz2
+#          tar jxvf $(ls acton-darwin*.tar.bz2 | tail -n1)
+#          echo "PATH=$(pwd)/acton/bin:$PATH" >> $GITHUB_ENV
+#      - name: "Build"
+#        run: |
+#          actonc build


### PR DESCRIPTION
Given that we are currently using a private repository we "only" get 2000 minutes for running GitHub Actions. That's quite a lot but as it turns out, MacOS has a 10x multiplier, so we end up with only 200 actual minutes. Given the very poor performance of actonc, just the compile takes ~15-20 minutes, e.g. around 10 jobs... per month. Not a lot. So disabling MacOS for now. The risk of introducing MacOS only bugs is probably fairly low anyway.