### PR TITLE
Add start, restart, stop actions to /telemetrify

### DIFF
--- a/telemetrify-nso/packages/telemetrify/python/telemetrify_shim/main.py
+++ b/telemetrify-nso/packages/telemetrify/python/telemetrify_shim/main.py
@@ -2,29 +2,78 @@ import logging
 import subprocess
 import sys
 import os
-import selectors
+import multiprocessing
 import threading
 
 import ncs
 
 log = logging.getLogger(__name__)
 
-# ---------------------------------------------
-# COMPONENT THREAD THAT WILL BE STARTED BY NCS.
-# ---------------------------------------------
+
+class RestartTelemetrify(ncs.dp.Action):
+    def init(self, init_args):
+        self.q = init_args[0]
+
+    @ncs.dp.Action.action
+    def cb_action(self, uinfo, name, kp, action_input, action_output, t_read):
+        self.q.put(name)
+
+
 class App(ncs.application.Application):
     def setup(self):
         self.log.info('telemetrify_shim SETUP')
-        bin_path = os.path.abspath(os.path.dirname(__file__) + "/../../bin/telemetrify.main.main")
-        self.log.info("starting: " + bin_path)
-        self.proc = subprocess.Popen(bin_path, stdout=sys.stdout, stderr=sys.stderr)
+        # We use a multiprocessing queue to communicate with the supervisor
+        # thread because the supervisor thread may run in a separate process,
+        # depending on the NSO configuration and the number of other application
+        # components in this package.
+        self.q = multiprocessing.Queue()
+        self.sup = Supervisor(self, self.log, self.q)
+        self.register_action('restart-telemetrify', RestartTelemetrify, init_args=(self.q, ))
+
+        self.sup.start()
+
         # self.watchdog = Watchdog(self, self.log)
         # self.watchdog.start()
 
     def teardown(self):
-        self.proc.terminate()
-        # self.watchdog.stop()
         self.log.info('telemetrify_shim TEARDOWN')
+        self.q.put('teardown')
+        self.sup.join()
+
+
+class Supervisor(threading.Thread):
+    def __init__(self, app, log, q: multiprocessing.Queue):
+        super().__init__()
+        self.app = app
+        self.log = log
+        self.q = q
+
+    def run(self) -> None:
+        self.app.add_running_thread(self.name)
+        self.telemetrify_start()
+
+        while action := self.q.get():
+            match action:
+                case 'start':
+                    self.telemetrify_start()
+                case 'restart':
+                    self.telemetrify_stop()
+                    self.telemetrify_start()
+                case 'stop':
+                    self.telemetrify_stop()
+                case 'teardown':
+                    self.telemetrify_stop()
+                    break
+        self.app.del_running_thread(self.name)
+
+    def telemetrify_start(self):
+        bin_path = os.path.abspath(os.path.dirname(__file__) + "/../../bin/telemetrify.main.main")
+        self.log.info("starting: " + bin_path)
+        self.proc = subprocess.Popen(bin_path, stdout=sys.stdout, stderr=sys.stderr)
+
+    def telemetrify_stop(self):
+        self.log.info("stopping telemetrify")
+        self.proc.terminate()
 
 # class Watchdog(threading.Thread):
 #     def __init__(self, app, log):

--- a/telemetrify-nso/packages/telemetrify/src/yang/telemetrify.yang
+++ b/telemetrify-nso/packages/telemetrify/src/yang/telemetrify.yang
@@ -282,5 +282,16 @@ module telemetrify {
         }
       }
     }
+    tailf:action restart {
+      tailf:actionpoint restart-telemetrify;
+    }
+
+    tailf:action start {
+      tailf:actionpoint restart-telemetrify;
+    }
+
+    tailf:action stop {
+      tailf:actionpoint restart-telemetrify;
+    }
   }
 }


### PR DESCRIPTION
Control the telemetrify "daemon" through actions rather than having to reload all packages. This is an intermediate solution until we use (something like) bgworker to handle other edge cases like HA, watchdog, ....