### PR TITLE
CdbCache improvements

### DIFF
--- a/src/telemetrify/common/mod.act
+++ b/src/telemetrify/common/mod.act
@@ -183,6 +183,9 @@ extension HTag(Hashable):
     def __hash__(self) -> int:
         return safe_hash(self.ns_hash + self.name_hash)
 
+def _eq_optional_value(a: ?value, b: ?value):
+    return a is not None and b is not None and _eq_value(a, b) or a is None and b is None
+
 def _eq_value(a: value, b: value) -> bool:
     if isinstance(a, int) and isinstance(b, int):
         return a == b
@@ -601,6 +604,12 @@ class TNode(Node):
     def iter(self) -> Iterator[TNode]:
         return [].__iter__()
 
+    def iter_ids(self) -> Iterator[Id]:
+        return [].__iter__()
+
+    def iter_items(self) -> Iterator[(Id, TNode)]:
+        return [].__iter__()
+
     def has_children(self) -> bool:
         return False
 
@@ -642,7 +651,7 @@ class TNode(Node):
     def _copy_deep(self, new_op: ?int) -> TNode:
         return self
 
-    def go(self, _id: value) -> TNode:
+    def go(self, _id: Id) -> TNode:
         """Try to get node or return dummy if not found."""
         node = self.get(_id)
         return node if node is not None else (TNode(OP_NONE, _id if isinstance(_id, Tag) else self._tag))
@@ -656,8 +665,11 @@ class TNode(Node):
     def exists(self) -> bool:
         return False
 
-    def get(self, _id: value) -> ?TNode:
+    def get(self, _id: Id) -> ?TNode:
         return None
+
+    def has_child(self, _id: Id) -> bool:
+        return False
 
     #
     # values
@@ -996,6 +1008,12 @@ class TTree(TNode):
     def iter(self) -> Iterator[TNode]:
         return self._children.values()
 
+    def iter_ids(self) -> Iterator[Id]:
+        return self._children.keys()
+
+    def iter_items(self) -> Iterator[(Id, TNode)]:
+        return self._children.items()
+
     def has_children(self) -> bool:
         return bool(self._children)
 
@@ -1028,14 +1046,15 @@ class TTree(TNode):
 
     def merge(self, other: TNode) -> TNode:
         if isinstance(other, TTree):
-            if other._op == OP_NOCREATE and self._op == OP_DELETE:
+            if other._op == OP_NOCREATE and self._op in [OP_DELETE, OP_REPLACE]:
                 return self
 
             if other._op in [OP_DELETE, OP_REPLACE]:
-                self.clear()
-                if other._op == OP_DELETE:
-                    if self._op != OP_NONE:
-                        self._op = other._op
+                if self._op == OP_NONE:
+                    self.clear()
+                else:
+                    if self._op != OP_DELETE:
+                        self._op = OP_REPLACE
             elif other._op == OP_MERGE:
                 if self._op == OP_DELETE:
                     self._op = OP_REPLACE
@@ -1049,7 +1068,7 @@ class TTree(TNode):
                         try_pop(self._children, child_id)
                     else:
                         self._children[child_id] = self_child.merge(other_child)
-                elif other_child._op in [OP_MERGE, OP_REPLACE]:
+                elif not (other_child._op == OP_NOCREATE and self._op == OP_NONE):
                     self._children[child_id] = other_child._copy_deep(OP_NONE if self._op == OP_NONE else None)
 
             return self
@@ -1065,19 +1084,25 @@ class TTree(TNode):
     def exists(self) -> bool:
         return self._op not in [OP_DELETE, OP_NOCREATE]
 
-    def get(self, _id: value) -> ?TNode:
-        if isinstance(_id, Id):
-            return try_get(self._children, _id)
-        # TODO: For future convenience
-        # elif isinstance(_id, str):
-        #     ...
-        # elif isinstance(_id, int):
-        #     ...
-        # elif isinstance(_id, list):
-        #     ...
-        # elif isinstance(_id, tuple):
-        #     ...
-        return None
+    # TODO: For future convenience
+    # def get(self, _id: value) -> ?TNode:
+    #     if isinstance(_id, Id):
+    #         return try_get(self._children, _id)
+    #     elif isinstance(_id, str):
+    #         ...
+    #     elif isinstance(_id, int):
+    #         ...
+    #     elif isinstance(_id, list):
+    #         ...
+    #     elif isinstance(_id, tuple):
+    #         ...
+    #     return None
+
+    def get(self, _id: Id) -> ?TNode:
+        return try_get(self._children, _id)
+
+    def has_child(self, _id: Id) -> bool:
+        return _id in self._children
 
     #
     # Node

--- a/src/telemetrify/ietf/cat8k.act
+++ b/src/telemetrify/ietf/cat8k.act
@@ -193,7 +193,7 @@ actor IpSlaTransform(
         else:
             ip_sla_stats: IpSlaStats = _ip_sla_stats
 
-            root = TTree(OP_NONE, ITag.root(), None, {})
+            root = TTree(OP_MERGE, ITag.root(), None, {})
 
             # TODO: DELETE/REPLACE based on l3vpn-svc?
 

--- a/src/telemetrify/ietf/l3vpn_svc.act
+++ b/src/telemetrify/ietf/l3vpn_svc.act
@@ -99,7 +99,8 @@ actor L3vpnSvcTracker(env: Env, shared_schema: schema.SharedSchema):
                 # CustomerNameRefiner.id(), # For DEBUG printouts only
                 L3vpnSvcParamsRefiner.id()
             ],
-            lambda r: _on_config_update(r, s))], _on_config_cache_error)
+            lambda r: _on_config_update(r, s))], _on_config_cache_error,
+            None)
 
     def _on_config_update(refiner_updates: dict[int, list[(Keypath, ?value)]], shared_schema: schema.SharedSchema):
         for refiner_id, updates in refiner_updates.items():

--- a/src/telemetrify/main/config.act
+++ b/src/telemetrify/main/config.act
@@ -131,20 +131,37 @@ class DeviceSourceVmanageRefiner(PassthroughRefiner):
 SOURCE_KEY_NETCONF = Keypath([Key(['netconf'])])
 SOURCE_KEY_VMANAGE_HTTP = Keypath([Key(['vmanage-http'])])
 
+SUBSCRIPTION_TYPE_KEY_ACTION_POLLER = PTag('tlm', 'netconf-rpc-poll')
+SUBSCRIPTION_TYPE_KEY_GET_POLLER = PTag('tlm', 'netconf-get-poll')
+SUBSCRIPTION_TYPE_KEY_VMANAGE_POLLER = PTag('tlm', 'vmanage-poll')
+
+_SUBSCRIPTION_TYPE_SOURCE_LOOKUP = {
+    SUBSCRIPTION_TYPE_KEY_ACTION_POLLER: SOURCE_KEY_NETCONF,
+    SUBSCRIPTION_TYPE_KEY_GET_POLLER: SOURCE_KEY_NETCONF,
+    SUBSCRIPTION_TYPE_KEY_VMANAGE_POLLER: SOURCE_KEY_VMANAGE_HTTP
+}
+
 class DeviceSourceRefiner(Refiner):
     @property
     device_source_configs: dict[Keypath, dict[Keypath, TNode]]
+    @property
+    device_source_subs: dict[Keypath, set[Keypath]]
+    @property
+    device_sub_sources: dict[Keypath, Keypath]
 
     def __init__(self):
         self.priority = 0
         self.subscription_dependencies = [
             ]
         self.refiner_dependencies = [
+                DeviceSubscriptionSourceRefiner.id(),
                 DeviceSourceNetconfRefiner.id(),
                 DeviceSourceVmanageRefiner.id(),
             ]
 
         self.device_source_configs = {}
+        self.device_source_subs = {}
+        self.device_sub_sources = {}
 
     @staticmethod
     def id() -> int:
@@ -152,6 +169,39 @@ class DeviceSourceRefiner(Refiner):
 
     def update(self, root: TNode, input_subs: dict[SubscriptionIdentity, list[Keypath]], input_refiners: dict[int, (Refiner, list[Keypath])]) -> list[Keypath]:
         updated: set[Keypath] = set([])
+
+        dev_sub_source_refiner, dev_sub_keys = input_refiners[DeviceSubscriptionSourceRefiner.id()]
+
+        for dev_sub_key in dev_sub_keys:
+            dev_key = dev_sub_key.try_slice(0, 1)
+            sub_key = dev_sub_key.try_slice(1, 2)
+            if dev_key is not None and sub_key is not None:
+                source_key: ?Keypath = None
+
+                state = dev_sub_source_refiner.state(dev_sub_key)
+                if state is not None and isinstance(state, TNode):
+                    sub_source_node: TNode = state
+                    for sub_type_id in sub_source_node.iter_ids():
+                        try:
+                            source_key = _SUBSCRIPTION_TYPE_SOURCE_LOOKUP[sub_type_id]
+                        except KeyError:
+                            raise ValueError("Missing _SUBSCRIPTION_TYPE_SOURCE_LOOKUP entry for: " + str(sub_type_id))
+                        else:
+                            break
+
+                if source_key is not None:
+                    dev_source_key = dev_key + source_key
+                    if dev_source_key not in self.device_source_subs:
+                        updated.add(dev_source_key)
+                    dict_set_add(self.device_source_subs, dev_source_key, sub_key)
+                    self.device_sub_sources[dev_sub_key] = source_key
+                else:
+                    source_key = try_pop(self.device_sub_sources, dev_sub_key)
+                    if source_key is not None:
+                        dev_source_key = dev_key + source_key
+                        dict_set_discard(self.device_source_subs, dev_source_key, sub_key)
+                        if dev_source_key not in self.device_source_subs:
+                            updated.add(dev_source_key)
 
         source_deps = [
             (SOURCE_KEY_NETCONF, input_refiners[DeviceSourceNetconfRefiner.id()]),
@@ -177,12 +227,13 @@ class DeviceSourceRefiner(Refiner):
         return list(iter(updated))
 
     def state(self, keys: Keypath) -> ?value:
-        device_key = keys.try_slice(0, 1)
-        source_key = keys.try_slice(1, 2)
-        if device_key is not None and source_key is not None:
-            sources = try_get(self.device_source_configs, device_key)
-            if sources is not None:
-                return try_get(sources, source_key)
+        if keys in self.device_source_subs:
+            device_key = keys.try_slice(0, 1)
+            source_key = keys.try_slice(1, 2)
+            if device_key is not None and source_key is not None:
+                sources = try_get(self.device_source_configs, device_key)
+                if sources is not None:
+                    return try_get(sources, source_key)
         return None
 
 class DeviceStreamerConfig(object):

--- a/src/telemetrify/main/main.act
+++ b/src/telemetrify/main/main.act
@@ -44,10 +44,6 @@ import telemetrify.vmanage.transform
 # class Poll(object):
 #     pass
 
-_SUBSCRIPTION_TYPE_ACTION_POLLER = PTag('tlm', 'netconf-rpc-poll')
-_SUBSCRIPTION_TYPE_VMANAGE_POLLER = PTag('tlm', 'vmanage-poll')
-_SUBSCRIPTION_TYPE_GET_POLLER = PTag('tlm', 'netconf-get-poll')
-
 def tnode_empty() -> TNode:
     return TNode(OP_NONE, PTag.root())
 
@@ -478,10 +474,10 @@ actor NetconfSource(auth: WorldCap, shared_schema: schema.SharedSchema, log_hand
     def _create_subscriber(dev_sub_key: Keypath, sub_update: SubscriptionUpdate) -> Subscriber:
         sub_config = sub_update.config
         if sub_config is not None:
-            if sub_config[_SUBSCRIPTION_TYPE_ACTION_POLLER].exists():
+            if sub_config[SUBSCRIPTION_TYPE_KEY_ACTION_POLLER].exists():
                 sub_act = NetconfRpcPollSubscription(self, dev_sub_key, shared_schema, logh)
                 return Subscriber(sub_act.update_config, sub_act.start, sub_act.stop, sub_act.close)
-            elif sub_config[_SUBSCRIPTION_TYPE_GET_POLLER].exists():
+            elif sub_config[SUBSCRIPTION_TYPE_KEY_GET_POLLER].exists():
                 sub_act = NetconfGetPollSubscription(self, dev_sub_key, shared_schema, logh)
                 return Subscriber(sub_act.update_config, sub_act.start, sub_act.stop, sub_act.close)
 
@@ -568,6 +564,7 @@ actor NetconfSource(auth: WorldCap, shared_schema: schema.SharedSchema, log_hand
             subscriber.close()
         #subscribers.clear()
         subscribers = {}
+        log.info("SOURCE netconf CLOSED", None)
 
 def _source_params_try_append_dev_sub(source_params: TNode, dev_sub_key: Keypath):
     _device_name_key = dev_sub_key.try_get_key(0)
@@ -680,7 +677,7 @@ actor NetconfRpcPollSubscription(source: NetconfSource, dev_sub_key: Keypath, sh
             _stop_poller()
             log.debug("SUBSCRIBER netconf-rpc-poll CONFIG", {"config": _config})
 
-            poll = _config[PTag('tlm', 'netconf-rpc-poll')]
+            poll = _config[SUBSCRIPTION_TYPE_KEY_ACTION_POLLER]
             path = poll[PTag('tlm', 'path')].try_str()
             period_ms = poll[PTag('tlm', 'period')].try_int()
 
@@ -779,6 +776,7 @@ actor NetconfRpcPollSubscription(source: NetconfSource, dev_sub_key: Keypath, sh
 
     def close():
         stop()
+        log.info("SUBSCRIBER netconf-rpc-poll CLOSED", None)
 
 actor VManageSource(auth: WorldCap, shared_schema: schema.SharedSchema, log_handler: ?logging.Handler):
     var logh = logging.Handler("vmanage-source")
@@ -847,7 +845,7 @@ actor VManageSource(auth: WorldCap, shared_schema: schema.SharedSchema, log_hand
     def _create_subscriber(dev_sub_key: Keypath, sub_update: SubscriptionUpdate) -> Subscriber:
         sub_config = sub_update.config
         if sub_config is not None:
-            if sub_config[_SUBSCRIPTION_TYPE_VMANAGE_POLLER].exists():
+            if sub_config[SUBSCRIPTION_TYPE_KEY_VMANAGE_POLLER].exists():
                 sub_act = VManagePollSubscription(self, dev_sub_key, shared_schema, logh)
                 return Subscriber(sub_act.update_config, sub_act.start, sub_act.stop, sub_act.close)
 
@@ -911,7 +909,7 @@ actor VManageSource(auth: WorldCap, shared_schema: schema.SharedSchema, log_hand
             subscriber.close()
         #subscribers.clear()
         subscribers = {}
-
+        log.info("SOURCE vmanage CLOSED", None)
 
 actor VManagePollSubscription(source: VManageSource, dev_sub_key: Keypath, shared_schema: schema.SharedSchema, log_handler: logging.Handler):
     var logh = logging.Handler("vmanage-poll-subscription")
@@ -930,7 +928,7 @@ actor VManagePollSubscription(source: VManageSource, dev_sub_key: Keypath, share
 
     var is_running: bool = False
 
-    log.info("SUBSCRIBER vmanage CREATED", None)
+    log.info("SUBSCRIBER vmanage-poll CREATED", None)
 
     def _do_poll(seqno: int, poll_ts: time.Instant):
         if seqno != poller_seqno:
@@ -1025,7 +1023,7 @@ actor VManagePollSubscription(source: VManageSource, dev_sub_key: Keypath, share
         if _config is not None:
             _stop_poller()
 
-            poll = _config[PTag('tlm', 'vmanage-poll')]
+            poll = _config[SUBSCRIPTION_TYPE_KEY_VMANAGE_POLLER]
             path = poll[PTag('tlm', 'path')].try_str()
             period_ms = poll[PTag('tlm', 'period')].try_int()
 
@@ -1070,6 +1068,7 @@ actor VManagePollSubscription(source: VManageSource, dev_sub_key: Keypath, share
 
     def close():
         stop()
+        log.info("SUBSCRIBER vmanage-poll CLOSED", None)
 
 actor NetconfGetPollSubscription(source: NetconfSource, dev_sub_key: Keypath, shared_schema: schema.SharedSchema, log_handler: ?logging.Handler):
     var logh = logging.Handler("netconf-get-poll")
@@ -1253,7 +1252,7 @@ actor NetconfGetPollSubscription(source: NetconfSource, dev_sub_key: Keypath, sh
             _stop_poller()
             log.debug("SUBSCRIBER netconf-get-poll CONFIG", {"_config": _config})
 
-            poll = _config[PTag('tlm', 'netconf-get-poll')]
+            poll = _config[SUBSCRIPTION_TYPE_KEY_GET_POLLER]
             path = poll[PTag('tlm', 'path')].try_str()
             period_ms = poll[PTag('tlm', 'period')].try_int()
 
@@ -1359,7 +1358,8 @@ actor NetconfGetPollSubscription(source: NetconfSource, dev_sub_key: Keypath, sh
             _stop_poller()
 
     def close():
-        pass
+        stop()
+        log.info("DEVICE netconf-get-poll CLOSED", None)
 
 class SubscriptionUpdate(object):
     @property
@@ -1472,11 +1472,11 @@ actor DeviceStreamer(env: Env, name: str, shared_schema: schema.SharedSchema, sh
                 del sources[source_key]
 
     def _get_subscription_source_key(state: TNode) -> Keypath:
-        if state[_SUBSCRIPTION_TYPE_ACTION_POLLER].exists():
+        if state[SUBSCRIPTION_TYPE_KEY_ACTION_POLLER].exists():
             return SOURCE_KEY_NETCONF
-        if state[_SUBSCRIPTION_TYPE_GET_POLLER].exists():
+        if state[SUBSCRIPTION_TYPE_KEY_GET_POLLER].exists():
             return SOURCE_KEY_NETCONF
-        if state[_SUBSCRIPTION_TYPE_VMANAGE_POLLER].exists():
+        if state[SUBSCRIPTION_TYPE_KEY_VMANAGE_POLLER].exists():
             return SOURCE_KEY_VMANAGE_HTTP
 
         raise Exception("Unknown subscription type: " + str(state))
@@ -1566,6 +1566,7 @@ actor DeviceStreamer(env: Env, name: str, shared_schema: schema.SharedSchema, sh
             sink.close()
         #sinks.clear()
         sinks = {}
+        log.info("DEVICE CLOSED", {"name": name})
 
 actor SharedResources(env: Env, shared_schema: schema.SharedSchema):
     var l3vpn_svc_tracker: ?telemetrify.ietf.l3vpn_svc.L3vpnSvcTracker = None
@@ -1642,8 +1643,8 @@ actor main(env):
             [([
                 #DeviceSettingsRefiner.id(), # For DEBUG printouts only
                 DeviceStreamerRefiner.id(),
-                DeviceSourceNetconfRefiner.id(), # For DEBUG printouts only
-                DeviceSourceVmanageRefiner.id(), # For DEBUG printouts only
+                #DeviceSourceNetconfRefiner.id(), # For DEBUG printouts only
+                #DeviceSourceVmanageRefiner.id(), # For DEBUG printouts only
                 DeviceSourceRefiner.id(),
                 DeviceSubscriptionSourceRefiner.id(),
                 #DeviceSubscriptionSinkBaseRefiner.id(), # For DEBUG printouts purposes

--- a/src/telemetrify/main/main.act
+++ b/src/telemetrify/main/main.act
@@ -1599,6 +1599,9 @@ actor main(env):
     var logh = logging.Handler("telemetrify")
     var log = logging.Logger(logh)
 
+    logh.set_output_level(logging.NOTICE)
+    logh.add_sink(logging.StdoutSink())
+
     def _on_maapi_connect_error(e):
         log.error("MAAPI connect failed:" + str(e), None)
 
@@ -1652,7 +1655,8 @@ actor main(env):
                 #SinkRefiner.id(), # For DEBUG printouts purposes
                 DeviceSinksRefiner.id()
             ],
-            lambda r: _on_config_update(r, s))], _on_config_cache_error)
+            lambda r: _on_config_update(r, s))], _on_config_cache_error,
+            logh)
         #await async env.exit(0)
 
     def _on_config_update(refiner_updates: dict[int, list[(Keypath, ?value)]], shared_schema: schema.SharedSchema):

--- a/src/telemetrify/nso/subscriber.act
+++ b/src/telemetrify/nso/subscriber.act
@@ -11,6 +11,8 @@
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
+import logging
+
 from telemetrify.common.mod import *
 from telemetrify.common.utils import *
 from telemetrify.nsoapi.cdb import *
@@ -22,6 +24,14 @@ from telemetrify.nsoapi.schema import *
 SUB_TYPE_RUNNING = CDB_SUB_TYPE_RUNNING
 # SUB_TYPE_RUNNING_TWOPHASE = CDB_SUB_TYPE_RUNNING_TWOPHASE
 SUB_TYPE_OPERATIONAL = CDB_SUB_TYPE_OPERATIONAL
+
+def sub_type_str(sub_type: int) -> str:
+    if sub_type == SUB_TYPE_RUNNING:
+        return "SUB_TYPE_OPERATIONAL"
+    elif sub_type == SUB_TYPE_OPERATIONAL:
+        return "SUB_TYPE_OPERATIONAL"
+    else:
+        raise Exception("Not Implemented")
 
 class SubscriptionSpec(object):
     @property
@@ -42,6 +52,9 @@ class SubscriptionIdentity(object):
     def __init__(self, path: Keypath, sub_type: int):
         self.path = path
         self.sub_type = sub_type
+
+    def __str__(self) -> str:
+        return "SubscriptionIdentity(" + str(self.path) + ", " + sub_type_str(self.sub_type) + ")"
 
 extension SubscriptionIdentity(Hashable):
     def __eq__(self, other: SubscriptionIdentity) -> bool:
@@ -138,6 +151,9 @@ class PassthroughRefiner(Refiner):
     @property
     subtrees: dict[Keypath, TNode]
 
+    # @property
+    # key_tree: KeyTree
+
     def __init__(self, subscription_spec: SubscriptionSpec):
         self.priority = 0
         self.subscription_dependencies = [subscription_spec]
@@ -148,13 +164,11 @@ class PassthroughRefiner(Refiner):
         _subtrees: dict[Keypath, TNode] = {}
 
         sub_identity = self.subscription_dependencies[0].identity
-        keys = input_subs[sub_identity]
+        keypaths = input_subs[sub_identity]
 
-        ancestor_deleted_keys = []
-
-        for key in keys:
-            key_index = 0
-            key_len = len(key)
+        for keypath in keypaths:
+            keypath_index = 0
+            keypath_len = len(keypath)
 
             node = root
             sub_path = sub_identity.path
@@ -162,30 +176,29 @@ class PassthroughRefiner(Refiner):
             for path_index in range(0, len(sub_path), 1):
                 _id: Id = sub_path[path_index]
                 if isinstance(_id, Key) and _id.is_wildcard():
-                    if key_index < key_len:
-                        node = node[key[key_index]]
-                        key_index += 1
-                    else:
-                        #for deleted_key_tail in _get_subtree_path_keys(node, sub_path[path_index:]):
-                        for deleted_key_tail in _get_subtree_path_keys(node, sub_path.get_slice(path_index, len(sub_path))):
-                            ancestor_deleted_keys.append(key + deleted_key_tail)
-                        break
+                    if keypath_index < keypath_len:
+                        node = node[keypath[keypath_index]]
+                        keypath_index += 1
                 else:
                     node = node[_id]
+                if not node.exists():
+                    break
 
             if node.exists():
-                _subtrees[key] = node
+                _subtrees[keypath] = node
+            else:
+                try_pop(_subtrees, keypath)
 
         self.subtrees = _subtrees
 
-        return keys + ancestor_deleted_keys if ancestor_deleted_keys else keys
+        return keypaths
 
     def state(self, keys: Keypath) -> ?value:
         return try_get(self.subtrees, keys)
 
-def _get_subpath_num_keys(sub_path: Keypath) -> int:
+def _get_path_num_keys(path: Keypath) -> int:
     c = 0
-    for _id in sub_path:
+    for _id in path:
         if isinstance(_id, Key):
             c += 1
     return c
@@ -230,12 +243,33 @@ def _get_subtree_keys(node: TNode, max_keys: int) -> list[Keypath]:
                 keys.append(Keypath(list(curr_keys)))
     return keys
 
+class SubscriptionParams(object):
+    @property
+    identity: SubscriptionIdentity
+    # @property
+    # max_keys: int
+    @property
+    delete_only_filter_path: ?EKeypath
+
+    #def __init__(self, identity: SubscriptionIdentity, max_keys: int, delete_only_filter_path: ?EKeypath):
+    def __init__(self, identity: SubscriptionIdentity, delete_only_filter_path: ?EKeypath):
+        self.identity = identity
+        #self.max_keys = max_keys
+        self.delete_only_filter_path = delete_only_filter_path
+
 actor CdbCache(cdb_sub_conn: CdbConnection,
             cdb_cmd_conn: CdbConnection,
             shared_schema: SharedSchema,
             refiner_ctors: list[pure() -> Refiner],
             callbacks: list[(list[int], action(dict[int, list[(Keypath, ?value)]]) -> None)],
-            on_error: action(Exception) -> None):
+            on_error: action(Exception) -> None,
+            log_handler: ?logging.Handler):
+
+    var logh = logging.Handler("cdb-cache")
+    if log_handler is not None:
+        logh.set_handler(log_handler)
+
+    var log = logging.Logger(logh)
 
     var _refiners: dict[int, Refiner] = {}
     var _callback_indexes: dict[int, list[int]] = {}
@@ -243,7 +277,9 @@ actor CdbCache(cdb_sub_conn: CdbConnection,
     #var _schema = shared_schema.shared_schema()
     var _schema = unsafe_get_shared_schema(shared_schema)
 
-    var _sub_ids: dict[int, (SubscriptionIdentity, int, set[Refiner])] = {}
+    var _sub_id_params: dict[int, SubscriptionParams] = {}
+    var _pending_setup_sub_params: dict[SubscriptionIdentity, SubscriptionParams] = {}
+    var __subscription_dependents: dict[SubscriptionIdentity, list[Refiner]] = {}
     var __refiner_dependents: dict[Refiner, list[Refiner]] = {}
 
     var _pending_sub_ids: list[int] = []
@@ -251,78 +287,85 @@ actor CdbCache(cdb_sub_conn: CdbConnection,
 
     var _root = TTree(OP_NONE, PTag.root(), None, {})
 
-    def _assign_priority(r: Refiner):
-        if r.priority == 0:
-            #r.priority = 1 + max([_assign_priority(_refiners[i]) for i in r.refiner_dependencies], 0)
-            mp = 0
-            for i in r.refiner_dependencies:
-                dp = _assign_priority(_refiners[i])
-                if dp > mp:
-                    mp = dp
-            r.priority = 1 + mp
-        return r.priority
+    var _stree = STree()
 
-    sub_specs: dict[SubscriptionIdentity, SubscriptionSpec] = {}
+    # Workaround actonc: Name _pending_setup_sub_params is not in scope
+    def _clear_pending_setup_sub_params():
+        #_pending_setup_sub_params.clear()
+        _pending_setup_sub_params = {}
 
-    for c in refiner_ctors:
-        r = c()
-        for sub_spec in r.subscription_dependencies:
-            identity = sub_spec.identity
-            existing_spec = try_get(sub_specs, identity)
-            if existing_spec is not None:
-                # Merge specs
-                #existing_spec.is_required |= sub_spec.is_required # Type error?
-                if existing_spec.is_required:
-                    sub_spec.is_required = True
-            else:
-                sub_specs[identity] = sub_spec
-        if r.id() in _refiners:
-            raise ValueError("ERROR: CdbCache - Attempted to register duplicate refiner-id")
-        _refiners[r.id()] = r
+    def _init() -> None:
+        def _assign_priority(r: Refiner):
+            if r.priority == 0:
+                #r.priority = 1 + max([_assign_priority(_refiners[i]) for i in r.refiner_dependencies], 0)
+                mp = 0
+                for i in r.refiner_dependencies:
+                    dp = _assign_priority(_refiners[i])
+                    if dp > mp:
+                        mp = dp
+                r.priority = 1 + mp
+            return r.priority
 
-    for r in _refiners.values():
-        _assign_priority(r)
-        for refiner_id in r.refiner_dependencies:
-            dependency = _refiners[refiner_id]
-            dict_list_append(__refiner_dependents, dependency, r)
+        for c in refiner_ctors:
+            r = c()
 
-    for i in range(0, len(callbacks), 1):
-        dependency_ids = callbacks[i].0
-        for dependency_id in dependency_ids:
-            dict_list_append(_callback_indexes, dependency_id, i)
+            for sub_spec in r.subscription_dependencies:
+                _stree.add_subscription(sub_spec)
+                dict_list_append(__subscription_dependents, sub_spec.identity, r)
+
+            if r.id() in _refiners:
+                raise ValueError("ERROR: CdbCache - Attempted to register duplicate refiner-id")
+            _refiners[r.id()] = r
+
+        for r in _refiners.values():
+            _assign_priority(r)
+            for refiner_id in r.refiner_dependencies:
+                dependency = _refiners[refiner_id]
+                dict_list_append(__refiner_dependents, dependency, r)
+
+        for i in range(0, len(callbacks), 1):
+            dependency_ids = callbacks[i].0
+            for dependency_id in dependency_ids:
+                dict_list_append(_callback_indexes, dependency_id, i)
+
+        _pending_setup_sub_params, inner_sub_specs = _stree.prepare_subscriptions(_schema)
+
+        _SubscriptionSetup(cdb_sub_conn, inner_sub_specs, shared_schema, _on_sub_event, _on_subscription_success, on_error, logh)
 
     def update() -> None:
-        updated_subs: dict[SubscriptionIdentity, list[Keypath]] = {}
-        updated_refiners: dict[Refiner, list[Keypath]] = {}
-        scheduled_refiners: set[Refiner] = set([])
+        combined_merge_root = TTree(OP_MERGE, PTag.root(), None, {})
 
-        #schedule_heap: MinHeap[Refiner] = MinHeap()
-        schedule_heap: MinHeap_Ord2[Refiner] = MinHeap_Ord2()
-
+        # Build combined merge root
         for sub_id, etvs in _pending_sub_modifications:
-            merge_root = etagvals_to_ttree(etvs, Cursor(_schema))
+            updated_keys: set[Keypath]
+            merge_root = etagvals_to_merge_ttree(etvs, Cursor(_schema))
             if isinstance(merge_root, TTree):
-                #print("Got ttree: " + str(merge_root))
-                _root.merge(merge_root)
-                #print("New root: " + str(_root))
-
-                sub_entry = try_get(_sub_ids, sub_id)
-                if sub_entry is not None:
-                    sub_identity, max_keys, refiners = sub_entry
-                    #print("For: ", sub_path, "max_keys:", max_keys)
-                    keys = _get_subtree_keys(merge_root, max_keys)
-                    #print("Got keys: " + list_str(keys))
-                    updated_subs[sub_identity] = keys
-                    for refiner in refiners:
-                        if refiner not in scheduled_refiners:
-                            #schedule_heap.insert(refiner)
-                            MinHeap_Ord2.insert(schedule_heap, refiner)
-                            scheduled_refiners.add(refiner)
-
+                #log.debug("Got subscription event merge root", {"sub_id": sub_id, "ttree": merge_root})
+                combined_merge_root.merge(merge_root)
             elif isinstance(merge_root, Exception):
                 on_error(Exception("Get modifications to tnode conversion error: " + merge_root.error_message))
 
         _pending_sub_modifications.clear()
+
+        #log.debug("Combined merge", {"merge_root": combined_merge_root})
+
+        # Schedule subscription-triggered refiners
+        updated_subs: dict[SubscriptionIdentity, list[Keypath]] = _stree.evaluate_subscriptions(_root, combined_merge_root)
+        scheduled_refiners: set[Refiner] = set([])
+        #schedule_heap: MinHeap[Refiner] = MinHeap()
+        schedule_heap: MinHeap_Ord2[Refiner] = MinHeap_Ord2()
+
+        for sub_identity in updated_subs.keys():
+            for refiner in __subscription_dependents[sub_identity]:
+                #schedule_heap.insert(refiner)
+                MinHeap_Ord2.insert(schedule_heap, refiner)
+                scheduled_refiners.add(refiner)
+
+        # Apply combined merge
+        _root.merge(combined_merge_root)
+
+        # Update refiners
+        updated_refiners: dict[Refiner, list[Keypath]] = {}
 
         while True:
             #curr_refiner = schedule_heap.try_pop()
@@ -347,6 +390,7 @@ actor CdbCache(cdb_sub_conn: CdbConnection,
             else:
                 break
 
+        # Invoke callbacks of updated refiners
         trigger_callback_indexes: set[int] = set([])
         for refiner in scheduled_refiners:
             refiner_id = refiner.id()
@@ -365,38 +409,40 @@ actor CdbCache(cdb_sub_conn: CdbConnection,
 
     def _on_sub_event(c: CdbConnection, v: value) -> None:
         if isinstance(v, list):
-            print("Sub event: Triggered sub-ids:", v)
+            log.debug("Sub event triggered", {"sub-ids": v})
             _pending_sub_ids = v
             _do_get_modifications()
         elif isinstance(v, Exception):
-            print("Sub event error:", v.error_message)
+            log.error("Sub event error", {"msg": v.error_message})
             on_error(Exception("Sub event error: " + v.error_message))
         else:
-            print("Sub event error:", v)
+            log.error("Sub event error", {"msg": v})
             on_error(Exception("Sub event error: " + str(v)))
 
     def _do_get_modifications():
         #if _pending_sub_ids:
         if len(_pending_sub_ids) > 0:
             sub_id = list_pop(_pending_sub_ids)
-            # TODO: Why does setting a ?EKeypath parameter to None result in actonc: Cannot infer None < telemetrify.nsoapi.conf.EKeypath
-            #cdb_sub_conn.get_modifications(sub_id, CDB_GET_MODS_INCLUDE_LISTS | CDB_GET_MODS_WANT_ANCESTOR_DELETE, None, _on_get_modifications)
-            cdb_sub_conn.get_modifications(sub_id, CDB_GET_MODS_INCLUDE_LISTS | CDB_GET_MODS_WANT_ANCESTOR_DELETE, EKeypath([]), lambda c, v: _on_get_modifications(c, v, sub_id))
+
+            sub_params = _sub_id_params[sub_id]
+            filter_path: ?EKeypath = sub_params.delete_only_filter_path
+
+            # actonc: ?_ is not a subclass of telemetrify.nsoapi.conf.EKeypath
+            #cdb_sub_conn.get_modifications(sub_id, CDB_GET_MODS_INCLUDE_LISTS | CDB_GET_MODS_WANT_ANCESTOR_DELETE, filter_path, lambda c, v: _on_get_modifications(c, v, sub_id))
+            cdb_sub_conn.get_modifications(sub_id, CDB_GET_MODS_INCLUDE_LISTS | CDB_GET_MODS_WANT_ANCESTOR_DELETE, filter_path if filter_path is not None else EKeypath([]), lambda c, v: _on_get_modifications(c, v, sub_id))
         else:
             cdb_sub_conn.sync_subscription_socket(CDB_SUB_SYNC_DONE_PRIORITY, _on_sync_subscription_socket, _on_sub_event)
 
     def _on_get_modifications(c: CdbConnection, v: value, sub_id: int):
         if isinstance(v, EList):
-            #
-            print(v)
-            #
+            #log.debug("_on_get_modification" {"eobj": v})
             _pending_sub_modifications.append((sub_id, v))
             _do_get_modifications()
         elif isinstance(v, Exception):
-            print("Get modifications error:", v.error_message)
+            log.error("Get modifications error", {"msg": v.error_message})
             on_error(Exception("Get modifications error: " + v.error_message))
         else:
-            print("Get modifications error:", v)
+            log.error("Get modifications error", {"msg": v})
             on_error(Exception("Get modifications error: " + str(v)))
 
     def _on_sync_subscription_socket(c: CdbConnection, v: ?Exception):
@@ -406,21 +452,21 @@ actor CdbCache(cdb_sub_conn: CdbConnection,
 
     def _on_subscription_success(sub_ids: dict[SubscriptionIdentity, int]) -> None:
         for sub_identity, sub_id in sub_ids.items():
-            _sub_ids[sub_id] = (sub_identity, _get_subpath_num_keys(sub_identity.path), set([]))
-        for refiner in _refiners.values():
-            _sub_specs = refiner.subscription_dependencies
-            for sub_spec in _sub_specs:
-                sub_id = try_get(sub_ids, sub_spec.identity)
-                if sub_id is not None:
-                    _sub_ids[sub_id].2.add(refiner)
+            sub_params = _pending_setup_sub_params[sub_identity]
+            _sub_id_params[sub_id] = sub_params
+
+        #_pending_setup_sub_params.clear()
+        #_pending_setup_sub_params = {}
+        # Workaround actonc: Name _pending_setup_sub_params is not in scope
+        _clear_pending_setup_sub_params()
 
         if not _trigger_subscriptions():
             _trigger_oper_subscriptions()
 
     def _trigger_subscriptions() -> bool:
         trigger_ids: set[int] = set([])
-        for sub_id, (sub_identity, _1, _2) in _sub_ids.items():
-            if sub_identity.sub_type != SUB_TYPE_OPERATIONAL:
+        for sub_id, sub_params in _sub_id_params.items():
+            if sub_params.identity.sub_type != SUB_TYPE_OPERATIONAL:
                 trigger_ids.add(sub_id)
 
         if trigger_ids:
@@ -436,8 +482,8 @@ actor CdbCache(cdb_sub_conn: CdbConnection,
 
     def _trigger_oper_subscriptions():
         trigger_ids: list[int] = []
-        for sub_id, (sub_identity, _1, _2) in _sub_ids.items():
-            if sub_identity.sub_type == SUB_TYPE_OPERATIONAL:
+        for sub_id, sub_params in _sub_id_params.items():
+            if sub_params.identity.sub_type == SUB_TYPE_OPERATIONAL:
                 trigger_ids.append(sub_id)
 
         if trigger_ids:
@@ -447,11 +493,296 @@ actor CdbCache(cdb_sub_conn: CdbConnection,
         if v is not None:
             on_error(Exception("Initial trigger_oper_subscriptions error: " + str(v.error_message)))
 
-    _SubscriptionSetup(cdb_sub_conn, list(sub_specs.values()), shared_schema, _on_sub_event, _on_subscription_success, on_error)
+    _init()
+
+class STree(object):
+    @property
+    root: SNode
+
+    def __init__(self):
+        self.root = SNode(PTag.root(), {}, None)
+
+    def add_subscription(self, spec: SubscriptionSpec):
+        return self._add_subscription(spec, None)
+
+    def _add_subscription(self, spec: SubscriptionSpec, ancestor_delete_fallback_origin: ?SubscriptionIdentity):
+        n = self.root
+        for _id in spec.identity.path:
+            n = n.go(_id)
+        n.add_subscription(spec, ancestor_delete_fallback_origin)
+
+    def prepare_subscriptions(self, _schema: Schema) -> (dict[SubscriptionIdentity, SubscriptionParams], list[SubscriptionSpec]):
+        # Prune invalid subscriptions that are not 'required' and prepare ancestor delete fallback config subscriptions
+        def _validate_and_prepare_fallback_subs(n: SNode, path: list[Id], _cursor: Cursor, is_valid: bool):
+            _sdata = n.sdata
+            if _sdata is not None:
+                if is_valid:
+                    if _sdata.identity.sub_type == SUB_TYPE_OPERATIONAL:
+                        found_deletable_config_ancestor = False
+                        cursor = Cursor(_schema)
+                        path_len = len(path)
+                        i = 0
+                        while i < path_len:
+                            _id = path[i]
+                            if isinstance(_id, Tag):
+                                cursor.push(_id)
+                                schema_node = cursor.node()
+                                if schema_node.is_oper():
+                                    break
+                                if schema_node.is_list() or schema_node.is_p_container():
+                                    found_deletable_config_ancestor = True
+                            i += 1
+                        if found_deletable_config_ancestor:
+                            self._add_subscription(
+                                    SubscriptionSpec(SubscriptionIdentity(Keypath(path[0:i]), CDB_SUB_TYPE_RUNNING), _sdata.is_required),
+                                    _sdata.identity)
+                else:
+                    if _sdata.is_required:
+                        raise ValueError("Invalid subscription path: " + str(Keypath(list(path))))
+                    else:
+                        n.sdata = None
+            return True
+
+        self._traverse_stree(_validate_and_prepare_fallback_subs, _schema)
+
+        # Prepare inner (i.e. actually registered to cdb) subscriptions
+        params: dict[SubscriptionIdentity, SubscriptionParams] = {}
+        specs: list[SubscriptionSpec] = []
+
+        def _prepare_inner_subs(n: SNode, path: list[Id], cursor: Cursor, is_valid: bool, sub_type: int):
+            _sdata = n.sdata
+            if _sdata is not None:
+                identity = _sdata.identity
+                if identity.sub_type == sub_type:
+                    do_recurse = False
+                    delete_only_filter_path: ?EKeypath = None
+                    ancestor_delete_fallback_origin = _sdata.ancestor_delete_fallback_origin
+                    if ancestor_delete_fallback_origin is not None:
+                        # TODO: Does cdb.get-modifications accept a filter path for a 'config' path that ends in 'oper'?
+                        #_delete_only_filter_path: EKeypath = keypath_to_ekeypath(ancestor_delete_fallback_origin, Cursor(_schema), True)
+                        # do_recurse = True
+                        pass
+                    params[identity] = SubscriptionParams(identity, delete_only_filter_path)
+                    specs.append(SubscriptionSpec(identity, _sdata.is_required))
+                    return do_recurse
+            return True
+
+        # actonc: Name n is not in scope
+        #self._traverse_stree(lambda n, p, c, v: _prepare_inner_subs(n, p, c, v, SUB_TYPE_RUNNING), _schema)
+        def _prepare_inner_config_subs(n: SNode, path: list[Id], cursor: Cursor, is_valid: bool):
+            return _prepare_inner_subs(n, path, cursor, is_valid, SUB_TYPE_RUNNING)
+        self._traverse_stree(_prepare_inner_config_subs, _schema)
+        # actonc: Name n is not in scope
+        #self._traverse_stree(lambda n, p, c, v: _prepare_inner_subs(n, p, c, v, SUB_TYPE_OPERATIONAL), _schema)
+        def _prepare_inner_oper_subs(n: SNode, path: list[Id], cursor: Cursor, is_valid: bool):
+            return _prepare_inner_subs(n, path, cursor, is_valid, SUB_TYPE_OPERATIONAL)
+        self._traverse_stree(_prepare_inner_oper_subs, _schema)
+
+        return (params, specs)
+
+    def _traverse_stree(self, visit: mut(SNode, list[Id], Cursor, bool) -> bool, _schema: Schema):
+        stack: list[(SNode, bool, bool)] = []
+        for c in self.root.children.values():
+            stack.append((c, True, True))
+
+        cursor = Cursor(_schema)
+        path: list[Id] = []
+
+        while stack:
+            n, is_valid, do_enter = list_pop(stack)
+            n_id = n._id
+
+            if do_enter:
+                if is_valid:
+                    if isinstance(n_id, Tag):
+                        if not cursor.push(n_id):
+                            is_valid = False
+                    elif isinstance(n_id, Key):
+                        if not n_id.is_wildcard():
+                            # TODO: Support non-wildcard keys
+                            raise ValueError("Support for non-wildcard not (yet) implemented - subscription path: " + str(Keypath(list(path))))
+
+                path.append(n_id)
+
+                do_recurse = visit(n, path, cursor, is_valid)
+
+                stack.append((n, is_valid, False))
+
+                if do_recurse:
+                    for c in n.children.values():
+                        stack.append((c, is_valid, True))
+            else:
+                list_pop(path)
+                if is_valid and isinstance(n_id, Tag):
+                    cursor.pop()
+
+    def evaluate_subscriptions(self, root: TNode, merge_root: TNode) -> dict[SubscriptionIdentity, list[Keypath]]:
+        trigger: dict[SubscriptionIdentity, list[Keypath]] = {}
+
+        keys: list[Id] = []
+
+        def _visit(state: ?TNode, update: ?TNode, parent_op: int, snode: ?SNode, s_count: int):
+            is_updated: bool = False
+
+            key: ?Key = update.key() if update is not None else state.key() if state is not None else None
+            if key is not None:
+                keys.append(key)
+
+            sdata = snode.sdata if snode is not None else None
+            if sdata is not None:
+                s_count += 1
+
+            op = parent_op
+            if update is not None:
+                op = update.op()
+                if op == OP_MERGE and parent_op in [OP_REPLACE, OP_DELETE]:
+                    op = OP_REPLACE
+
+            # print("_visit(" + (optional_str(root.tag(), "None") if root is not None else "None") +
+            #         ", " + (optional_str(update.tag(), "None") if update is not None else "None") + ")" +
+            #         ", " + op_str(op) +
+            #         ", " + (str(sdata.identity) if sdata is not None else "None") +
+            #         ", " + str(s_count) +
+            #         ")")
+
+            def _get_c_snodes(c_id: Id) -> list[SNode]:
+                c_snodes: list[SNode] = []
+                if snode is not None:
+                    if isinstance(c_id, Key) and not c_id.is_wildcard():
+                        _c_wildcard_snode = try_get(snode.children, Key.wildcard())
+                        if _c_wildcard_snode is not None:
+                            c_snodes.append(_c_wildcard_snode)
+                    _c_snode = try_get(snode.children, c_id)
+                    if _c_snode is not None:
+                        c_snodes.append(_c_snode)
+                return c_snodes
+
+            if op == OP_DELETE:
+                if state is not None:
+                    is_updated = True
+
+                    for c_id, c in state.iter_items():
+                        if snode is not None:
+                            c_snodes = _get_c_snodes(c_id)
+                            for c_snode in c_snodes:
+                                _visit(c, None, op, c_snode, s_count)
+
+            elif update is not None:
+
+                def _visit_children(update_children: Iterator[(Id, TNode)]) -> bool:
+                    is_updated: bool = False
+                    for c_id, c in update.iter_items():
+                        c_snodes = _get_c_snodes(c_id)
+                        if c_snodes:
+                            for c_snode in c_snodes:
+                                c_is_updated = _visit(state.get(c_id) if state is not None else None, c, op, c_snode, s_count)
+                                is_updated = is_updated or c_is_updated
+                        elif not is_updated and s_count > 0:
+                            c_is_updated = _visit(state.get(c_id) if state is not None else None, c, op, None, s_count)
+                            is_updated = is_updated or c_is_updated
+                    return is_updated
+
+                if op == OP_MERGE:
+                    if state is not None:
+                        is_updated = is_updated or not _eq_optional_value(update.value(), state.value())
+                    else:
+                        is_updated = True
+                    _is_updated = _visit_children(update.iter_items())
+                    is_updated = is_updated or _is_updated
+                elif op == OP_REPLACE:
+                    if state is not None:
+                        is_updated = is_updated or not _eq_optional_value(update.value(), state.value())
+
+                        for c_id, c in state.iter_items():
+                            if not update.has_child(c_id):
+                                is_updated = True
+                                if snode is not None:
+                                    c_snodes = _get_c_snodes(c_id)
+                                    for c_snode in c_snodes:
+                                        _visit(c, None, OP_DELETE, c_snode, s_count)
+                        _is_updated = _visit_children(update.iter_items())
+                        is_updated = is_updated or _is_updated
+                    else:
+                        _visit_children(update.iter_items())
+                        is_updated = True
+                elif op == OP_NOCREATE:
+                    for c_id, c in update.iter_items():
+                        c_state = state.get(c_id) if state is not None else None
+                        c_snodes = _get_c_snodes(c_id)
+                        if c_snodes:
+                            for c_snode in c_snodes:
+                                c_is_updated = _visit(c_state, c, op, c_snode, s_count)
+                                is_updated = is_updated or c_is_updated
+                        elif not is_updated and s_count > 0 and c_state is not None:
+                            c_is_updated = _visit(c_state, c, op, None, s_count)
+                            is_updated = is_updated or c_is_updated
+
+            #if is_updated and sdata is not None and sdata.ancestor_delete_fallback_origin is None:
+            if is_updated and sdata is not None:
+                _sdata_ancestor_delete_fallback_origin = sdata.ancestor_delete_fallback_origin
+                if _sdata_ancestor_delete_fallback_origin is None:
+                    dict_list_append(trigger, sdata.identity, Keypath(keys[0:sdata.num_keys]))
+
+            if key is not None:
+                list_pop(keys)
+
+            return is_updated
+
+        _visit(root, merge_root, merge_root.op(), self.root, 0)
+
+        return trigger
+
+class SNode(object):
+    @property
+    _id: Id
+    @property
+    children: dict[Id, SNode]
+    @property
+    sdata: ?SData
+
+    def __init__(self, _id: Id, children: dict[Id, SNode], sdata: ?SData):
+        self._id = _id
+        self.children = children
+        self.sdata = sdata
+
+    def go(self, _id: Id) -> SNode:
+        return get_or_create(self.children, _id, lambda: SNode(_id, {}, None))
+
+    def add_subscription(self, spec: SubscriptionSpec, ancestor_delete_fallback_origin: ?SubscriptionIdentity):
+        _sdata = self.sdata
+        if _sdata is not None:
+            if spec.identity != _sdata.identity:
+                raise ValueError("subscriber - Conflicting subscription specifications: " + str(spec.identity) + " vs " + str(_sdata.identity))
+            #_sdata.is_required |= spec.is_required # actonc: __builtin__.bool does not implement __builtin__.Logical
+            _sdata.is_required = _sdata.is_required or spec.is_required
+            old_ancestor_delete_fallback_origin = _sdata.ancestor_delete_fallback_origin
+            if old_ancestor_delete_fallback_origin is not None:
+                pass # TODO: Find out if we even need to merge, or if we get the ancestor deletes that we want reusing the same filter-path?
+            # else: # Simply drop the origin as we already have a full subscription
+        else:
+            self.sdata = SData(spec.identity, spec.is_required, _get_path_num_keys(spec.identity.path), ancestor_delete_fallback_origin)
+
+class SData(object):
+    @property
+    identity: SubscriptionIdentity
+    @property
+    is_required: bool
+    @property
+    num_keys: int
+    @property
+    ancestor_delete_fallback_origin: ?SubscriptionIdentity # is not None -> Only to detect subtree deletes
+
+    def __init__(self, identity: SubscriptionIdentity, is_required: bool, num_keys: int, ancestor_delete_fallback_origin: ?SubscriptionIdentity):
+        self.identity = identity
+        self.is_required = is_required
+        self.ancestor_delete_fallback_origin = ancestor_delete_fallback_origin
 
 actor _SubscriptionSetup(cdb_sub_conn: CdbConnection, subscription_specs: list[SubscriptionSpec], shared_schema: SharedSchema,
                             sub_event_cb: action(CdbConnection, value) -> None,
-                            on_success: action(dict[SubscriptionIdentity, int]) -> None, on_error: action(Exception) -> None):
+                            on_success: action(dict[SubscriptionIdentity, int]) -> None, on_error: action(Exception) -> None,
+                            log_handler: logging.Handler):
+
+    var log = logging.Logger(log_handler)
 
     #var _schema = shared_schema.shared_schema()
     var _schema = unsafe_get_shared_schema(shared_schema)
@@ -475,7 +806,7 @@ actor _SubscriptionSetup(cdb_sub_conn: CdbConnection, subscription_specs: list[S
                     on_error(ValueError("Invalid subscription path: " + str(spec.identity.path)))
                     return
                 else:
-                    print("DEBUG: Invalid but non-required subscription path: " + str(spec.identity.path))
+                    log.debug("Invalid but non-required subscription", {"path": spec.identity.path})
 
         cdb_sub_conn.subscribe_done(_on_subscribe_done, sub_event_cb)
 
@@ -487,7 +818,7 @@ actor _SubscriptionSetup(cdb_sub_conn: CdbConnection, subscription_specs: list[S
                 on_error(ValueError("Invalid subscription path: " + str(spec.identity.path)))
                 return
             else:
-                print("DEBUG: Invalid but non-required subscription path: " + str(spec.identity.path))
+                log.debug("Invalid but non-required subscription", {"path": spec.identity.path})
         _do_subscribe()
 
     def _on_subscribe_done(c, e):

--- a/src/telemetrify/nsoapi/cdb.act
+++ b/src/telemetrify/nsoapi/cdb.act
@@ -119,7 +119,7 @@ actor CdbConnection(env: Env, port: int, name: str, on_connect: action(CdbConnec
     var conn: ?net.TCPConnection = None
 
     def _write(data: bytes):
-        print("CdbConnection TCP send:", data)
+        #print("CdbConnection TCP send:", data)
         if conn is not None:
             conn.write(data)
             # Looks like writes can be reordered unless we wait for them. E.g. actor -> actor ordering is violated?
@@ -242,10 +242,10 @@ actor CdbConnection(env: Env, port: int, name: str, on_connect: action(CdbConnec
         # print("CdbConnection TCP recv:", data)
         data_len: int = len(data)
         recv_bytes_total += data_len
-        if len(data) > 80:
-            print("CdbConnection TCP recv:", data[:80], " ... (len ", data_len, "), recv_total: ", recv_bytes_total)
-        else:
-            print("CdbConnection TCP recv:", data, ", recv_total: ", recv_bytes_total)
+        # if len(data) > 80:
+        #     print("CdbConnection TCP recv:", data[:80], " ... (len ", data_len, "), recv_total: ", recv_bytes_total)
+        # else:
+        #     print("CdbConnection TCP recv:", data, ", recv_total: ", recv_bytes_total)
         input_stream.append_data(data)
         # _post_poll_recv()
         if record_to is not None:
@@ -273,7 +273,7 @@ actor CdbConnection(env: Env, port: int, name: str, on_connect: action(CdbConnec
     def _send_cdb_request(queue, op: ?int, read_op: bool, req: ?EObject, response_cb: action(?value) -> None):
         payload_writer = BufferWriter()
         if req is not None and isinstance(req, EObject):
-            print("ENC EObject:", str(req))
+            #print("ENC EObject:", str(req))
             payload_writer.write_tag(_ERL_EXTERN_FMT)
             req.encode(payload_writer)
         payload_data = payload_writer.to_bytes()

--- a/src/telemetrify/nsoapi/conv.act
+++ b/src/telemetrify/nsoapi/conv.act
@@ -110,8 +110,8 @@ def _get_key_from_etagvals(etagvals: list[EObject], index: int, _len: int, curso
         index += 1
     return Key(key_elems)
 
-def etagvals_to_ttree(etagvallist: EList, cursor: Cursor) -> value: # (TTree | Exception)
-    root = TTree(OP_NONE, PTag.root(), None, {})
+def etagvals_to_merge_ttree(etagvallist: EList, cursor: Cursor) -> value: # (TTree | Exception)
+    root = TTree(OP_MERGE, PTag.root(), None, {})
     path: list[TNode] = [root]
 
     etagvals: list[EObject] = etagvallist.elems

--- a/src/telemetrify/nsoapi/schema.act
+++ b/src/telemetrify/nsoapi/schema.act
@@ -172,6 +172,12 @@ class Cursor:
         root_nsmaps = try_get(schema._mount_id_maps, ROOT_MOUNT_ID)
         self._mount_points.append((ROOT_MOUNT_ID, root_nsmaps) if root_nsmaps is not None else None)
 
+    def clone(self: Cursor):
+        other = Cursor(self._schema)
+        other._path.extend(self._path[1:])
+        other._mount_points.extend(self._mount_points)
+        return other
+
     def get_schema_path(self: Cursor) -> SchemaPath:
         tags: list[Tag] = []
         mount_ids: list[?HTag] = []

--- a/src/telemetrify/test.act
+++ b/src/telemetrify/test.act
@@ -717,7 +717,7 @@ actor test_etv_tnode(env: Env, opts: Opts):
 
             root = TTree(OP_NONE, PTag.root(), None, {})
             def do_merge(etvs):
-                merge_root = etagvals_to_ttree(etvs, Cursor(schema))
+                merge_root = etagvals_to_merge_ttree(etvs, Cursor(schema))
                 if isinstance(merge_root, TTree):
                     print("Got ttree:\n" + str(merge_root))
                     root.merge(merge_root)
@@ -797,7 +797,7 @@ actor test_subscriber(env: Env, opts: Opts):
         print("CDB (cmd) connected!!!!")
         cache = telemetrify.nso.subscriber.CdbCache(sc, cc, s,
             [DeviceSettingsRefiner],
-            [([DeviceSettingsRefiner.id()], _on_config_update)], _on_config_cache_error)
+            [([DeviceSettingsRefiner.id()], _on_config_update)], _on_config_cache_error, None)
         #await async env.exit(0)
 
     def _on_config_update(refiner_updates: dict[int, list[(Keypath, ?value)]]):

--- a/src/telemetrify/vmanage/transform.act
+++ b/src/telemetrify/vmanage/transform.act
@@ -78,7 +78,7 @@ actor Transform(
         except KeyError:
             pass # TODO: debug/trace log?
         else:
-            root = TTree(OP_NONE, ITag.root(), None, {})
+            root = TTree(OP_MERGE, ITag.root(), None, {})
 
             # TODO: DELETE/REPLACE based on l3vpn-svc?
 

--- a/tests/nso/Makefile
+++ b/tests/nso/Makefile
@@ -17,10 +17,10 @@ stop:
 	ncs --stop
 
 test:
-	$(BUILD_PATH)/bin/acton_streamer.test $(ARGS)
+	$(BUILD_PATH)/bin/telemetrify.test $(ARGS)
 
 test-debug:
-	gdb -ex 'handle SIGPWR SIGXCPU nostop noprint' --args $(BUILD_PATH)/bin/acton_streamer.test --rts-wthreads 1 $(ARGS)
+	gdb -ex 'handle SIGPWR SIGXCPU nostop noprint' --args $(BUILD_PATH)/bin/telemetrify.test --rts-wthreads 1 $(ARGS)
 
 cli:
 	ncs_cli -u admin


### PR DESCRIPTION
- Evaluate combined data tree merge rather than individual cdb-subscriber events to trigger subscribers
  - Refiners receive full path keys for ancestor deletes, hence less burden on refiner logic
  - Resolves missing oper updates due to cdb not triggering oper subscriptions on config ancestor deletes
- Aggregate cdb-subscriptions - i.e. prune cdb-subscribers that are subpaths of others
- Convert to logging
