### PR TITLE
Remove dependency on dt-sdwan

### DIFF
--- a/telemetrify-nso/Dockerfile.in
+++ b/telemetrify-nso/Dockerfile.in
@@ -1,16 +1,12 @@
 ARG NSO_IMAGE_PATH
 ARG NSO_VERSION
 
-FROM gitlab.dev.terastrm.net:4567/abs/dt-sdwan/nso:${NSO_VERSION} AS dt-sdwan
 # DEP_START
 # DEP_END
 
 # Compile local packages in the build stage
 FROM ${NSO_IMAGE_PATH}cisco-nso-dev:${NSO_VERSION} AS build
 ARG PKG_FILE
-
-# We just need a few packages and in particular the YANG models from these sources
-COPY --from=dt-sdwan /var/opt/ncs/packages/ietf-network-topology/ /includes/ietf-network-topology/
 
 # DEP_INC_START
 # DEP_INC_END

--- a/telemetrify-nso/Dockerfile.in
+++ b/telemetrify-nso/Dockerfile.in
@@ -2,7 +2,6 @@ ARG NSO_IMAGE_PATH
 ARG NSO_VERSION
 
 FROM gitlab.dev.terastrm.net:4567/abs/dt-sdwan/nso:${NSO_VERSION} AS dt-sdwan
-FROM gitlab.dev.terastrm.net:4567/abs/dt-mplsnet/nso:${NSO_VERSION} AS dt-mplsnet
 # DEP_START
 # DEP_END
 

--- a/telemetrify-nso/test-packages/ietf-network-topology/.gitignore
+++ b/telemetrify-nso/test-packages/ietf-network-topology/.gitignore
@@ -1,0 +1,1 @@
+load-dir

--- a/telemetrify-nso/test-packages/ietf-network-topology/README.md
+++ b/telemetrify-nso/test-packages/ietf-network-topology/README.md
@@ -1,0 +1,3 @@
+# IETF network topology models
+
+This package contains the IETF network topology models.

--- a/telemetrify-nso/test-packages/ietf-network-topology/package-meta-data.xml
+++ b/telemetrify-nso/test-packages/ietf-network-topology/package-meta-data.xml
@@ -1,0 +1,6 @@
+<ncs-package xmlns="http://tail-f.com/ns/ncs-packages">
+  <name>ietf-network-topology</name>
+  <package-version>1.0</package-version>
+  <description>The IETF network topology models</description>
+  <ncs-min-version>6.1</ncs-min-version>
+</ncs-package>

--- a/telemetrify-nso/test-packages/ietf-network-topology/src/Makefile
+++ b/telemetrify-nso/test-packages/ietf-network-topology/src/Makefile
@@ -1,0 +1,35 @@
+all: fxs
+.PHONY: all
+
+# Include standard NCS examples build definitions and rules
+include $(NCS_DIR)/src/ncs/build/include.ncs.mk
+
+ANN_SRC = $(wildcard yang/*-ann.yang)
+OSRC = $(wildcard yang/*.yang)
+SRC = $(filter-out $(ANN_SRC), $(OSRC))
+DIRS = ../load-dir
+FXS = $(SRC:yang/%.yang=../load-dir/%.fxs)
+
+## Uncomment and patch the line below if you have a dependency to a NED
+## or to other YANG files
+YANGPATH += yang
+
+NCSCPATH   = $(YANGPATH:%=--yangpath %)
+YANGERPATH = $(YANGPATH:%=--path %)
+
+fxs: $(DIRS) $(FXS)
+
+$(DIRS):
+	mkdir -p $@
+
+../load-dir/%.fxs: YANG_BASE=$(shell echo $*.yang | sed -e 's/\@.*//')
+../load-dir/%.fxs: ANN_AUG=$(shell ls yang/$(YANG_BASE)-ann.yang  > /dev/null 2>&1 && echo "-a yang/$(YANG_BASE)-ann.yang")
+../load-dir/%.fxs: yang/%.yang
+	echo $(YANG_BASE)
+	$(NCSC) $(ANN_AUG) \
+		$(NCSCPATH) \
+		-c -o $@ $<
+
+clean:
+	rm -rf $(DIRS)
+.PHONY: clean

--- a/telemetrify-nso/test-packages/ietf-network-topology/src/yang/dt-geo-location.yang
+++ b/telemetrify-nso/test-packages/ietf-network-topology/src/yang/dt-geo-location.yang
@@ -1,0 +1,99 @@
+//-*- coding: utf-8; fill-column: 69; evil-shift-width: 2; -*-
+//
+module dt-geo-location {
+  yang-version 1.1;
+  namespace "https://telekom.com/ns/yang/dt-geo-location";
+  prefix geo;
+  import ietf-inet-types { prefix inet; }
+  import ietf-yang-types { prefix types; }
+
+  description
+      "A module describing location of nodes.";
+
+  revision 2023-06-19 {
+    description "Initial Draft";
+  }
+
+  typedef coord {
+    type decimal64 {
+      fraction-digits 16;
+    }
+    units "decimal degrees";
+    description "Coordinate value.";
+  }
+
+  /* Typedefs */
+  typedef svc-id {
+    type string;
+    description "Defines a type of service component identifier.";
+  }
+
+  grouping geo-location-extensions {
+    container geo-location {
+      presence "geo-location";
+      leaf system {
+        type inet:uri;
+        default "WGS84";
+        description
+        "The system of measurement these coordinate values belong to.";
+      }
+      leaf latitude {
+        type coord;
+        description "The latitude";
+      }
+      leaf longitude {
+        type coord;
+        description "The longitude";
+      }
+      leaf height {
+        type coord;
+        units "meters";
+        description
+        "Height from a reference value of the object";
+      }
+      leaf timestamp {
+        type types:date-and-time;
+        description "Reference time when location was recorded.";
+      }
+    }
+  }
+  grouping dt-geo-location {
+    container location {
+      leaf address {
+        type string;
+        description
+        "Address (number and street) of the site.";
+      }
+      leaf postal-code {
+        type string;
+        description
+        "Postal code of the site.";
+      }
+      leaf state {
+        type string;
+        description
+        "State of the site.  This leaf can also be
+        used to describe a region for a country that
+        does not have states.";
+      }
+      leaf city {
+        type string;
+        description
+        "City of the site.";
+      }
+      leaf country-code {
+        type string {
+          pattern '[A-Z]{2}';
+        }
+        description
+        "Country of the site.
+        Expressed as ISO ALPHA-2 code.";
+      }
+      uses geo-location-extensions;
+      description
+      "Location of the site.";
+    }
+    description
+    "This grouping defines customer location parameters.";
+  }
+}

--- a/telemetrify-nso/test-packages/ietf-network-topology/src/yang/ietf-network-state-ann.yang
+++ b/telemetrify-nso/test-packages/ietf-network-topology/src/yang/ietf-network-state-ann.yang
@@ -1,0 +1,19 @@
+module ncs-augments {
+  namespace
+    "urn:dummy-ncs-augment-ietf-network";
+  prefix dummy-augment-ietf-nw-s;
+
+  import tailf-common {
+    prefix tailf;
+  }
+
+  description "This module includes augmentations of the IETF network.";
+
+  tailf:annotate-module ietf-network-state {
+    tailf:annotate-statement container[name='networks'] {
+      tailf:cdb-oper {
+        tailf:persistent "true";
+      }
+    }
+  }
+}

--- a/telemetrify-nso/test-packages/ietf-network-topology/src/yang/ietf-network-state@2018-02-26.yang
+++ b/telemetrify-nso/test-packages/ietf-network-topology/src/yang/ietf-network-state@2018-02-26.yang
@@ -1,0 +1,176 @@
+module ietf-network-state {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-network-state";
+  prefix nw-s;
+
+  import ietf-network {
+    prefix nw;
+    reference
+      "RFC 8345: A YANG Data Model for Network Topologies";
+  }
+
+  organization
+    "IETF I2RS (Interface to the Routing System) Working Group";
+
+  contact
+    "WG Web:    <https://datatracker.ietf.org/wg/i2rs/>
+     WG List:   <mailto:i2rs@ietf.org>
+
+     Editor:    Alexander Clemm
+                <mailto:ludwig@clemm.org>
+
+     Editor:    Jan Medved
+                <mailto:jmedved@cisco.com>
+
+     Editor:    Robert Varga
+                <mailto:robert.varga@pantheon.tech>
+
+     Editor:    Nitin Bahadur
+                <mailto:nitin_bahadur@yahoo.com>
+     Editor:    Hariharan Ananthakrishnan
+                <mailto:hari@packetdesign.com>
+
+     Editor:    Xufeng Liu
+                <mailto:xufeng.liu.ietf@gmail.com>";
+
+  description
+    "This module defines a common base data model for a collection
+     of nodes in a network.  Node definitions are further used
+     in network topologies and inventories.  It represents
+     information that either (1) is learned and automatically
+     populated or (2) results from applying network information
+     that has been configured per the 'ietf-network' data model,
+     mirroring the corresponding data nodes in this data model.
+
+     The data model mirrors 'ietf-network' but contains only
+     read-only state data.  The data model is not needed when the
+     underlying implementation infrastructure supports the Network
+     Management Datastore Architecture (NMDA).
+
+     Copyright (c) 2018 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 8345;
+     see the RFC itself for full legal notices.";
+
+  revision 2018-02-26 {
+    description
+      "Initial revision.";
+    reference
+      "RFC 8345: A YANG Data Model for Network Topologies";
+  }
+
+  grouping network-ref {
+    description
+      "Contains the information necessary to reference a network --
+       for example, an underlay network.";
+    leaf network-ref {
+      type leafref {
+        path "/nw-s:networks/nw-s:network/nw-s:network-id";
+      require-instance false;
+      }
+      description
+        "Used to reference a network -- for example, an underlay
+         network.";
+    }
+  }
+
+  grouping node-ref {
+    description
+      "Contains the information necessary to reference a node.";
+    leaf node-ref {
+      type leafref {
+        path "/nw-s:networks/nw-s:network[nw-s:network-id=current()"+
+          "/../network-ref]/nw-s:node/nw-s:node-id";
+        require-instance false;
+      }
+      description
+        "Used to reference a node.
+         Nodes are identified relative to the network that
+         contains them.";
+    }
+    uses network-ref;
+  }
+
+  container networks {
+    config false;
+    description
+      "Serves as a top-level container for a list of networks.";
+    list network {
+      key "network-id";
+      description
+        "Describes a network.
+         A network typically contains an inventory of nodes,
+         topological information (augmented through the
+         network-topology data model), and layering information.";
+      container network-types {
+        description
+          "Serves as an augmentation target.
+           The network type is indicated through corresponding
+           presence containers augmented into this container.";
+      }
+      leaf network-id {
+        type nw:network-id;
+        description
+          "Identifies a network.";
+      }
+      list supporting-network {
+        key "network-ref";
+        description
+          "An underlay network, used to represent layered network
+           topologies.";
+        leaf network-ref {
+          type leafref {
+            path "/nw-s:networks/nw-s:network/nw-s:network-id";
+          require-instance false;
+          }
+          description
+            "References the underlay network.";
+        }
+      }
+
+      list node {
+        key "node-id";
+        description
+          "The inventory of nodes of this network.";
+        leaf node-id {
+          type nw:node-id;
+          description
+            "Uniquely identifies a node within the containing
+             network.";
+        }
+        list supporting-node {
+          key "network-ref node-ref";
+          description
+            "Represents another node that is in an underlay network
+             and that supports this node.  Used to represent layering
+             structure.";
+          leaf network-ref {
+            type leafref {
+              path "../../../nw-s:supporting-network/nw-s:network-ref";
+            require-instance false;
+            }
+            description
+              "References the underlay network of which the
+               underlay node is a part.";
+          }
+          leaf node-ref {
+            type leafref {
+              path "/nw-s:networks/nw-s:network/nw-s:node/nw-s:node-id";
+            require-instance false;
+            }
+            description
+              "References the underlay node itself.";
+          }
+        }
+      }
+    }
+  }
+}

--- a/telemetrify-nso/test-packages/ietf-network-topology/src/yang/ietf-network-topology-state@2018-02-26.yang
+++ b/telemetrify-nso/test-packages/ietf-network-topology/src/yang/ietf-network-topology-state@2018-02-26.yang
@@ -1,0 +1,273 @@
+module ietf-network-topology-state {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-network-topology-state";
+  prefix nt-s;
+
+  import ietf-network-state {
+    prefix nw-s;
+    reference
+      "RFC 8345: A YANG Data Model for Network Topologies";
+  }
+  import ietf-network-topology {
+    prefix nt;
+    reference
+      "RFC 8345: A YANG Data Model for Network Topologies";
+  }
+
+  organization
+    "IETF I2RS (Interface to the Routing System) Working Group";
+
+  contact
+    "WG Web:    <https://datatracker.ietf.org/wg/i2rs/>
+     WG List:   <mailto:i2rs@ietf.org>
+
+     Editor:    Alexander Clemm
+                <mailto:ludwig@clemm.org>
+
+     Editor:    Jan Medved
+                <mailto:jmedved@cisco.com>
+
+     Editor:    Robert Varga
+                <mailto:robert.varga@pantheon.tech>
+
+     Editor:    Nitin Bahadur
+                <mailto:nitin_bahadur@yahoo.com>
+
+     Editor:    Hariharan Ananthakrishnan
+                <mailto:hari@packetdesign.com>
+
+     Editor:    Xufeng Liu
+                <mailto:xufeng.liu.ietf@gmail.com>";
+
+  description
+    "This module defines a common base data model for network
+     topology state, representing topology that either (1) is learned
+     or (2) results from applying topology that has been configured
+     per the 'ietf-network-topology' data model, mirroring the
+     corresponding data nodes in this data model.  It augments the
+     base network state data model with links to connect nodes, as
+     well as termination points to terminate links on nodes.
+
+     The data model mirrors 'ietf-network-topology' but contains only
+     read-only state data.  The data model is not needed when the
+     underlying implementation infrastructure supports the Network
+     Management Datastore Architecture (NMDA).
+
+     Copyright (c) 2018 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 8345;
+     see the RFC itself for full legal notices.";
+
+  revision 2018-02-26 {
+    description
+      "Initial revision.";
+    reference
+      "RFC 8345: A YANG Data Model for Network Topologies";
+  }
+
+  grouping link-ref {
+    description
+      "References a link in a specific network.  Although this
+       grouping is not used in this module, it is defined here for
+       the convenience of augmenting modules.";
+    leaf link-ref {
+      type leafref {
+        path "/nw-s:networks/nw-s:network[nw-s:network-id=current()"+
+          "/../network-ref]/nt-s:link/nt-s:link-id";
+        require-instance false;
+      }
+      description
+        "A type for an absolute reference to a link instance.
+         (This type should not be used for relative references.
+         In such a case, a relative path should be used instead.)";
+    }
+    uses nw-s:network-ref;
+  }
+
+  grouping tp-ref {
+    description
+      "References a termination point in a specific node.  Although
+       this grouping is not used in this module, it is defined here
+       for the convenience of augmenting modules.";
+    leaf tp-ref {
+      type leafref {
+        path "/nw-s:networks/nw-s:network[nw-s:network-id=current()"+
+          "/../network-ref]/nw-s:node[nw-s:node-id=current()/../"+
+          "node-ref]/nt-s:termination-point/nt-s:tp-id";
+        require-instance false;
+      }
+      description
+        "A type for an absolute reference to a termination point.
+         (This type should not be used for relative references.
+         In such a case, a relative path should be used instead.)";
+    }
+    uses nw-s:node-ref;
+  }
+
+  augment "/nw-s:networks/nw-s:network" {
+    description
+      "Add links to the network data model.";
+    list link {
+      key "link-id";
+      description
+        "A network link connects a local (source) node and
+         a remote (destination) node via a set of the respective
+         node's termination points.  It is possible to have several
+         links between the same source and destination nodes.
+         Likewise, a link could potentially be re-homed between
+         termination points.  Therefore, in order to ensure that we
+         would always know to distinguish between links, every link
+         is identified by a dedicated link identifier.  Note that a
+         link models a point-to-point link, not a multipoint link.";
+      container source {
+        description
+          "This container holds the logical source of a particular
+           link.";
+        leaf source-node {
+          type leafref {
+            path "../../../nw-s:node/nw-s:node-id";
+            require-instance false;
+          }
+          description
+            "Source node identifier.  Must be in the same topology.";
+        }
+        leaf source-tp {
+          type leafref {
+            path "../../../nw-s:node[nw-s:node-id=current()/../"+
+              "source-node]/termination-point/tp-id";
+            require-instance false;
+          }
+          description
+            "This termination point is located within the source node
+             and terminates the link.";
+        }
+      }
+      container destination {
+        description
+          "This container holds the logical destination of a
+           particular link.";
+        leaf dest-node {
+          type leafref {
+            path "../../../nw-s:node/nw-s:node-id";
+          require-instance false;
+          }
+          description
+            "Destination node identifier.  Must be in the same
+             network.";
+        }
+
+        leaf dest-tp {
+          type leafref {
+            path "../../../nw-s:node[nw-s:node-id=current()/../"+
+              "dest-node]/termination-point/tp-id";
+            require-instance false;
+          }
+          description
+            "This termination point is located within the
+             destination node and terminates the link.";
+        }
+      }
+      leaf link-id {
+        type nt:link-id;
+        description
+          "The identifier of a link in the topology.
+           A link is specific to a topology to which it belongs.";
+      }
+      list supporting-link {
+        key "network-ref link-ref";
+        description
+          "Identifies the link or links on which this link depends.";
+        leaf network-ref {
+          type leafref {
+            path "../../../nw-s:supporting-network/nw-s:network-ref";
+          require-instance false;
+          }
+          description
+            "This leaf identifies in which underlay topology
+             the supporting link is present.";
+        }
+        leaf link-ref {
+          type leafref {
+            path "/nw-s:networks/nw-s:network[nw-s:network-id="+
+              "current()/../network-ref]/link/link-id";
+            require-instance false;
+          }
+          description
+            "This leaf identifies a link that is a part
+             of this link's underlay.  Reference loops in which
+             a link identifies itself as its underlay, either
+             directly or transitively, are not allowed.";
+        }
+      }
+    }
+  }
+
+  augment "/nw-s:networks/nw-s:network/nw-s:node" {
+    description
+      "Augments termination points that terminate links.
+       Termination points can ultimately be mapped to interfaces.";
+    list termination-point {
+      key "tp-id";
+      description
+        "A termination point can terminate a link.
+         Depending on the type of topology, a termination point
+         could, for example, refer to a port or an interface.";
+      leaf tp-id {
+        type nt:tp-id;
+        description
+          "Termination point identifier.";
+      }
+      list supporting-termination-point {
+        key "network-ref node-ref tp-ref";
+        description
+          "This list identifies any termination points on which a
+           given termination point depends or onto which it maps.
+           Those termination points will themselves be contained
+           in a supporting node.  This dependency information can be
+           inferred from the dependencies between links.  Therefore,
+           this item is not separately configurable.  Hence, no
+           corresponding constraint needs to be articulated.
+           The corresponding information is simply provided by the
+           implementing system.";
+        leaf network-ref {
+          type leafref {
+            path "../../../nw-s:supporting-node/nw-s:network-ref";
+          require-instance false;
+          }
+          description
+            "This leaf identifies in which topology the
+             supporting termination point is present.";
+        }
+        leaf node-ref {
+          type leafref {
+            path "../../../nw-s:supporting-node/nw-s:node-ref";
+          require-instance false;
+          }
+          description
+            "This leaf identifies in which node the supporting
+             termination point is present.";
+        }
+
+        leaf tp-ref {
+          type leafref {
+            path "/nw-s:networks/nw-s:network[nw-s:network-id="+
+              "current()/../network-ref]/nw-s:node[nw-s:node-id="+
+              "current()/../node-ref]/termination-point/tp-id";
+            require-instance false;
+          }
+          description
+            "Reference to the underlay node (the underlay node must
+             be in a different topology).";
+        }
+      }
+    }
+  }
+}

--- a/telemetrify-nso/test-packages/ietf-network-topology/src/yang/ietf-network-topology@2018-02-26.yang
+++ b/telemetrify-nso/test-packages/ietf-network-topology/src/yang/ietf-network-topology@2018-02-26.yang
@@ -1,0 +1,294 @@
+module ietf-network-topology {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-network-topology";
+  prefix nt;
+
+  import ietf-inet-types {
+    prefix inet;
+    reference
+      "RFC 6991: Common YANG Data Types";
+  }
+  import ietf-network {
+    prefix nw;
+    reference
+      "RFC 8345: A YANG Data Model for Network Topologies";
+  }
+
+  organization
+    "IETF I2RS (Interface to the Routing System) Working Group";
+
+  contact
+    "WG Web:    <https://datatracker.ietf.org/wg/i2rs/>
+     WG List:   <mailto:i2rs@ietf.org>
+
+     Editor:    Alexander Clemm
+                <mailto:ludwig@clemm.org>
+
+     Editor:    Jan Medved
+                <mailto:jmedved@cisco.com>
+
+     Editor:    Robert Varga
+                <mailto:robert.varga@pantheon.tech>
+
+     Editor:    Nitin Bahadur
+                <mailto:nitin_bahadur@yahoo.com>
+
+     Editor:    Hariharan Ananthakrishnan
+                <mailto:hari@packetdesign.com>
+
+     Editor:    Xufeng Liu
+                <mailto:xufeng.liu.ietf@gmail.com>";
+
+  description
+    "This module defines a common base model for a network topology,
+     augmenting the base network data model with links to connect
+     nodes, as well as termination points to terminate links
+     on nodes.
+
+     Copyright (c) 2018 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 8345;
+     see the RFC itself for full legal notices.";
+
+  revision 2018-02-26 {
+    description
+      "Initial revision.";
+    reference
+      "RFC 8345: A YANG Data Model for Network Topologies";
+  }
+
+  typedef link-id {
+    type inet:uri;
+    description
+      "An identifier for a link in a topology.  The precise
+       structure of the link-id will be up to the implementation.
+       The identifier SHOULD be chosen such that the same link in a
+       real network topology will always be identified through the
+       same identifier, even if the data model is instantiated in
+       separate datastores.  An implementation MAY choose to capture
+       semantics in the identifier -- for example, to indicate the
+       type of link and/or the type of topology of which the link is
+       a part.";
+  }
+
+  typedef tp-id {
+    type inet:uri;
+    description
+      "An identifier for termination points on a node.  The precise
+       structure of the tp-id will be up to the implementation.
+       The identifier SHOULD be chosen such that the same termination
+       point in a real network topology will always be identified
+       through the same identifier, even if the data model is
+       instantiated in separate datastores.  An implementation MAY
+       choose to capture semantics in the identifier -- for example,
+       to indicate the type of termination point and/or the type of
+       node that contains the termination point.";
+  }
+
+  grouping link-ref {
+    description
+      "This grouping can be used to reference a link in a specific
+       network.  Although it is not used in this module, it is
+       defined here for the convenience of augmenting modules.";
+    leaf link-ref {
+      type leafref {
+        path "/nw:networks/nw:network[nw:network-id=current()/../"+
+          "network-ref]/nt:link/nt:link-id";
+        require-instance false;
+      }
+      description
+        "A type for an absolute reference to a link instance.
+         (This type should not be used for relative references.
+         In such a case, a relative path should be used instead.)";
+    }
+    uses nw:network-ref;
+  }
+
+  grouping tp-ref {
+    description
+      "This grouping can be used to reference a termination point
+       in a specific node.  Although it is not used in this module,
+       it is defined here for the convenience of augmenting
+       modules.";
+    leaf tp-ref {
+      type leafref {
+        path "/nw:networks/nw:network[nw:network-id=current()/../"+
+          "network-ref]/nw:node[nw:node-id=current()/../"+
+          "node-ref]/nt:termination-point/nt:tp-id";
+        require-instance false;
+      }
+      description
+        "A type for an absolute reference to a termination point.
+         (This type should not be used for relative references.
+         In such a case, a relative path should be used instead.)";
+    }
+    uses nw:node-ref;
+  }
+
+  augment "/nw:networks/nw:network" {
+    description
+      "Add links to the network data model.";
+    list link {
+      key "link-id";
+      description
+        "A network link connects a local (source) node and
+         a remote (destination) node via a set of the respective
+         node's termination points.  It is possible to have several
+         links between the same source and destination nodes.
+         Likewise, a link could potentially be re-homed between
+         termination points.  Therefore, in order to ensure that we
+         would always know to distinguish between links, every link
+         is identified by a dedicated link identifier.  Note that a
+         link models a point-to-point link, not a multipoint link.";
+      leaf link-id {
+        type link-id;
+        description
+          "The identifier of a link in the topology.
+           A link is specific to a topology to which it belongs.";
+      }
+      container source {
+        description
+          "This container holds the logical source of a particular
+           link.";
+        leaf source-node {
+          type leafref {
+            path "../../../nw:node/nw:node-id";
+            require-instance false;
+          }
+          description
+            "Source node identifier.  Must be in the same topology.";
+        }
+        leaf source-tp {
+          type leafref {
+            path "../../../nw:node[nw:node-id=current()/../"+
+              "source-node]/termination-point/tp-id";
+            require-instance false;
+          }
+          description
+            "This termination point is located within the source node
+             and terminates the link.";
+        }
+      }
+
+      container destination {
+        description
+          "This container holds the logical destination of a
+           particular link.";
+        leaf dest-node {
+          type leafref {
+            path "../../../nw:node/nw:node-id";
+          require-instance false;
+          }
+          description
+            "Destination node identifier.  Must be in the same
+             network.";
+        }
+        leaf dest-tp {
+          type leafref {
+            path "../../../nw:node[nw:node-id=current()/../"+
+              "dest-node]/termination-point/tp-id";
+            require-instance false;
+          }
+          description
+            "This termination point is located within the
+             destination node and terminates the link.";
+        }
+      }
+      list supporting-link {
+        key "network-ref link-ref";
+        description
+          "Identifies the link or links on which this link depends.";
+        leaf network-ref {
+          type leafref {
+            path "../../../nw:supporting-network/nw:network-ref";
+          require-instance false;
+          }
+          description
+            "This leaf identifies in which underlay topology
+             the supporting link is present.";
+        }
+
+        leaf link-ref {
+          type leafref {
+            path "/nw:networks/nw:network[nw:network-id=current()/"+
+              "../network-ref]/link/link-id";
+            require-instance false;
+          }
+          description
+            "This leaf identifies a link that is a part
+             of this link's underlay.  Reference loops in which
+             a link identifies itself as its underlay, either
+             directly or transitively, are not allowed.";
+        }
+      }
+    }
+  }
+  augment "/nw:networks/nw:network/nw:node" {
+    description
+      "Augments termination points that terminate links.
+       Termination points can ultimately be mapped to interfaces.";
+    list termination-point {
+      key "tp-id";
+      description
+        "A termination point can terminate a link.
+         Depending on the type of topology, a termination point
+         could, for example, refer to a port or an interface.";
+      leaf tp-id {
+        type tp-id;
+        description
+          "Termination point identifier.";
+      }
+      list supporting-termination-point {
+        key "network-ref node-ref tp-ref";
+        description
+          "This list identifies any termination points on which a
+           given termination point depends or onto which it maps.
+           Those termination points will themselves be contained
+           in a supporting node.  This dependency information can be
+           inferred from the dependencies between links.  Therefore,
+           this item is not separately configurable.  Hence, no
+           corresponding constraint needs to be articulated.
+           The corresponding information is simply provided by the
+           implementing system.";
+
+        leaf network-ref {
+          type leafref {
+            path "../../../nw:supporting-node/nw:network-ref";
+          require-instance false;
+          }
+          description
+            "This leaf identifies in which topology the
+             supporting termination point is present.";
+        }
+        leaf node-ref {
+          type leafref {
+            path "../../../nw:supporting-node/nw:node-ref";
+          require-instance false;
+          }
+          description
+            "This leaf identifies in which node the supporting
+             termination point is present.";
+        }
+        leaf tp-ref {
+          type leafref {
+            path "/nw:networks/nw:network[nw:network-id=current()/"+
+              "../network-ref]/nw:node[nw:node-id=current()/../"+
+              "node-ref]/termination-point/tp-id";
+            require-instance false;
+          }
+          description
+            "Reference to the underlay node (the underlay node must
+             be in a different topology).";
+        }
+      }
+    }
+  }
+}

--- a/telemetrify-nso/test-packages/ietf-network-topology/src/yang/ietf-network@2018-02-26.yang
+++ b/telemetrify-nso/test-packages/ietf-network-topology/src/yang/ietf-network@2018-02-26.yang
@@ -1,0 +1,192 @@
+module ietf-network {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-network";
+  prefix nw;
+
+  import ietf-inet-types {
+    prefix inet;
+    reference
+      "RFC 6991: Common YANG Data Types";
+  }
+
+  organization
+    "IETF I2RS (Interface to the Routing System) Working Group";
+
+  contact
+    "WG Web:    <https://datatracker.ietf.org/wg/i2rs/>
+     WG List:   <mailto:i2rs@ietf.org>
+
+     Editor:    Alexander Clemm
+                <mailto:ludwig@clemm.org>
+
+     Editor:    Jan Medved
+                <mailto:jmedved@cisco.com>
+
+     Editor:    Robert Varga
+                <mailto:robert.varga@pantheon.tech>
+
+     Editor:    Nitin Bahadur
+                <mailto:nitin_bahadur@yahoo.com>
+
+     Editor:    Hariharan Ananthakrishnan
+                <mailto:hari@packetdesign.com>
+
+     Editor:    Xufeng Liu
+                <mailto:xufeng.liu.ietf@gmail.com>";
+  description
+    "This module defines a common base data model for a collection
+     of nodes in a network.  Node definitions are further used
+     in network topologies and inventories.
+
+     Copyright (c) 2018 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 8345;
+     see the RFC itself for full legal notices.";
+
+  revision 2018-02-26 {
+    description
+      "Initial revision.";
+    reference
+      "RFC 8345: A YANG Data Model for Network Topologies";
+  }
+
+  typedef node-id {
+    type inet:uri;
+    description
+      "Identifier for a node.  The precise structure of the node-id
+       will be up to the implementation.  For example, some
+       implementations MAY pick a URI that includes the network-id
+       as part of the path.  The identifier SHOULD be chosen
+       such that the same node in a real network topology will
+       always be identified through the same identifier, even if
+       the data model is instantiated in separate datastores.  An
+       implementation MAY choose to capture semantics in the
+       identifier -- for example, to indicate the type of node.";
+  }
+
+  typedef network-id {
+    type inet:uri;
+    description
+      "Identifier for a network.  The precise structure of the
+       network-id will be up to the implementation.  The identifier
+       SHOULD be chosen such that the same network will always be
+       identified through the same identifier, even if the data model
+       is instantiated in separate datastores.  An implementation MAY
+       choose to capture semantics in the identifier -- for example,
+       to indicate the type of network.";
+  }
+
+  grouping network-ref {
+    description
+      "Contains the information necessary to reference a network --
+       for example, an underlay network.";
+    leaf network-ref {
+      type leafref {
+        path "/nw:networks/nw:network/nw:network-id";
+      require-instance false;
+      }
+      description
+        "Used to reference a network -- for example, an underlay
+         network.";
+    }
+  }
+
+  grouping node-ref {
+    description
+      "Contains the information necessary to reference a node.";
+    leaf node-ref {
+      type leafref {
+        path "/nw:networks/nw:network[nw:network-id=current()/../"+
+          "network-ref]/nw:node/nw:node-id";
+        require-instance false;
+      }
+      description
+        "Used to reference a node.
+         Nodes are identified relative to the network that
+         contains them.";
+    }
+    uses network-ref;
+  }
+
+  container networks {
+    description
+      "Serves as a top-level container for a list of networks.";
+    list network {
+      key "network-id";
+      description
+        "Describes a network.
+         A network typically contains an inventory of nodes,
+         topological information (augmented through the
+         network-topology data model), and layering information.";
+      leaf network-id {
+        type network-id;
+        description
+          "Identifies a network.";
+      }
+      container network-types {
+        description
+          "Serves as an augmentation target.
+           The network type is indicated through corresponding
+           presence containers augmented into this container.";
+      }
+      list supporting-network {
+        key "network-ref";
+        description
+          "An underlay network, used to represent layered network
+           topologies.";
+        leaf network-ref {
+          type leafref {
+            path "/nw:networks/nw:network/nw:network-id";
+          require-instance false;
+          }
+          description
+            "References the underlay network.";
+        }
+      }
+
+      list node {
+        key "node-id";
+        description
+          "The inventory of nodes of this network.";
+        leaf node-id {
+          type node-id;
+          description
+            "Uniquely identifies a node within the containing
+             network.";
+        }
+        list supporting-node {
+          key "network-ref node-ref";
+          description
+            "Represents another node that is in an underlay network
+             and that supports this node.  Used to represent layering
+             structure.";
+          leaf network-ref {
+            type leafref {
+              path "../../../nw:supporting-network/nw:network-ref";
+            require-instance false;
+            }
+            description
+              "References the underlay network of which the
+               underlay node is a part.";
+          }
+          leaf node-ref {
+            type leafref {
+              path "/nw:networks/nw:network/nw:node/nw:node-id";
+            require-instance false;
+            }
+            description
+              "References the underlay node itself.";
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Instead of pulling in the *ietf-network-state* package from dt-sdwan, place a copy in `telemetrify-nso/test-packages` directly. If we want others to use this then we must remove all internal dependencies.