### PR TITLE
Add subscription source configuration for ned-id or default to device/live-status-protocol ned-id

### DIFF
--- a/src/telemetrify/main/config.act
+++ b/src/telemetrify/main/config.act
@@ -13,7 +13,7 @@
 
 from telemetrify.common.mod import *
 from telemetrify.common.utils import *
-from telemetrify.nso.subscriber import Refiner, PassthroughRefiner, SubscriptionSpec, SubscriptionIdentity, SUB_TYPE_RUNNING
+from telemetrify.nso.subscriber import Refiner, PassthroughRefiner, MirrorRefiner, SubscriptionSpec, SubscriptionIdentity, SUB_TYPE_RUNNING
 
 class DeviceSettings(object):
     @property
@@ -106,6 +106,107 @@ class DeviceSettingsRefiner(Refiner):
         if authgroup_keys is not None:
             return try_get(self._authgroup_configs, authgroup_keys)
         return None
+
+class DeviceNedIdBaseRefiner(MirrorRefiner):
+    @property
+    _workaround_actonc_issue_1598: bool
+
+    def __init__(self):
+        self._workaround_actonc_issue_1598 = True # https://github.com/actonlang/acton/issues/1598
+        MirrorRefiner.__init__(self,
+            [
+                SubscriptionSpec(SubscriptionIdentity(Keypath([
+                    PTag('ncs', 'devices'),
+                    PTag('ncs', 'device'),
+                    Key.wildcard(),
+                    PTag('ncs', 'device-type'),
+                    PTag('ncs', 'netconf'),
+                    PTag('ncs', 'ned-id'),
+                    ]),
+                    SUB_TYPE_RUNNING), True),
+                SubscriptionSpec(SubscriptionIdentity(Keypath([
+                    PTag('ncs', 'devices'),
+                    PTag('ncs', 'device'),
+                    Key.wildcard(),
+                    PTag('ncs', 'device-type'),
+                    PTag('ncs', 'generic'),
+                    PTag('ncs', 'ned-id'),
+                    ]),
+                    SUB_TYPE_RUNNING), True),
+                SubscriptionSpec(SubscriptionIdentity(Keypath([
+                    PTag('ncs', 'devices'),
+                    PTag('ncs', 'device'),
+                    Key.wildcard(),
+                    PTag('ncs', 'device-type'),
+                    PTag('ncs', 'cli'),
+                    PTag('ncs', 'ned-id'),
+                    ]),
+                    SUB_TYPE_RUNNING), True),
+                SubscriptionSpec(SubscriptionIdentity(Keypath([
+                    PTag('ncs', 'devices'),
+                    PTag('ncs', 'device'),
+                    Key.wildcard(),
+                    PTag('ncs', 'device-type'),
+                    PTag('ncs', 'snmp'),
+                    PTag('ncs', 'ned-id'),
+                    ]),
+                    SUB_TYPE_RUNNING), True),
+
+                SubscriptionSpec(SubscriptionIdentity(Keypath([
+                    PTag('ncs', 'devices'),
+                    PTag('ncs', 'device'),
+                    Key.wildcard(),
+                    PTag('ncs', 'live-status-protocol'),
+                    Key.wildcard(),
+                    PTag('ncs', 'device-type'),
+                    PTag('ncs', 'netconf'),
+                    PTag('ncs', 'ned-id'),
+                    ]),
+                    SUB_TYPE_RUNNING), True),
+                SubscriptionSpec(SubscriptionIdentity(Keypath([
+                    PTag('ncs', 'devices'),
+                    PTag('ncs', 'device'),
+                    Key.wildcard(),
+                    PTag('ncs', 'live-status-protocol'),
+                    Key.wildcard(),
+                    PTag('ncs', 'device-type'),
+                    PTag('ncs', 'generic'),
+                    PTag('ncs', 'ned-id'),
+                    ]),
+                    SUB_TYPE_RUNNING), True),
+                SubscriptionSpec(SubscriptionIdentity(Keypath([
+                    PTag('ncs', 'devices'),
+                    PTag('ncs', 'device'),
+                    Key.wildcard(),
+                    PTag('ncs', 'live-status-protocol'),
+                    Key.wildcard(),
+                    PTag('ncs', 'device-type'),
+                    PTag('ncs', 'cli'),
+                    PTag('ncs', 'ned-id'),
+                    ]),
+                    SUB_TYPE_RUNNING), True),
+                SubscriptionSpec(SubscriptionIdentity(Keypath([
+                    PTag('ncs', 'devices'),
+                    PTag('ncs', 'device'),
+                    Key.wildcard(),
+                    PTag('ncs', 'live-status-protocol'),
+                    Key.wildcard(),
+                    PTag('ncs', 'device-type'),
+                    PTag('ncs', 'snmp'),
+                    PTag('ncs', 'ned-id'),
+                    ]),
+                    SUB_TYPE_RUNNING), True)
+            ],
+            Keypath([
+                PTag('ncs', 'devices'),
+                PTag('ncs', 'device'),
+                Key.wildcard()
+                ])
+            )
+
+    @staticmethod
+    def id() -> int:
+        return 1012
 
 class DeviceSourceNetconfRefiner(PassthroughRefiner):
     def __init__(self):
@@ -307,7 +408,132 @@ class DeviceStreamerRefiner(Refiner):
     def state(self, keys: Keypath) -> ?value:
         return try_get(self.device_configs, keys)
 
-class DeviceSubscriptionSourceRefiner(PassthroughRefiner):
+class SchemaSettings(object):
+    @property
+    config_ned_id: ?HTag
+    @property
+    live_status_ned_id: ?HTag
+
+    def __init__(self, config_ned_id: ?HTag, live_status_ned_id: ?HTag):
+        self.config_ned_id = config_ned_id
+        self.live_status_ned_id = live_status_ned_id
+
+    def __str__(self) -> str:
+        return self.__repr__()
+
+    def __repr__(self):
+        return "SchemaSettings(" + optional_str(self.config_ned_id, "None") + ", " + optional_str(self.live_status_ned_id, "None") + ")"
+
+    @staticmethod
+    def from_device_config_and_schema_config(device_config: TNode, schema_config: TNode) -> SchemaSettings:
+        ned_id = SchemaSettings._get_schema_config_ned_id(schema_config)
+        if ned_id is not None:
+            return SchemaSettings(ned_id, ned_id)
+
+        base_ned_id = SchemaSettings._get_device_type_ned_id(device_config)
+        live_ned_id = base_ned_id
+
+        # TODO: How to (and do we want to) handle multiple live-status-protocol ned-ids?
+        # For now we require schema-setting override in case of many...
+        for live_status_protocol_elem in device_config[PTag('ncs', 'live-status-protocol')]:
+            _ned_id = SchemaSettings._get_device_type_ned_id(live_status_protocol_elem)
+            if _ned_id is not None:
+                live_ned_id = _ned_id
+                break
+
+        return SchemaSettings(base_ned_id, live_ned_id)
+
+    @staticmethod
+    def _get_device_type_ned_id(base_node: TNode) -> ?HTag:
+        device_type_node = base_node[PTag('ncs', 'device-type')]
+        ned_id: ?HTag = None
+        ned_id = device_type_node[PTag('ncs', 'netconf')][PTag('ncs', 'ned-id')].try_htag()
+        if ned_id is not None:
+            return ned_id
+        ned_id = device_type_node[PTag('ncs', 'generic')][PTag('ncs', 'ned-id')].try_htag()
+        if ned_id is not None:
+            return ned_id
+        ned_id = device_type_node[PTag('ncs', 'cli')][PTag('ncs', 'ned-id')].try_htag()
+        if ned_id is not None:
+            return ned_id
+        ned_id = device_type_node[PTag('ncs', 'snmp')][PTag('ncs', 'ned-id')].try_htag()
+        if ned_id is not None:
+            return ned_id
+        return None
+
+    @staticmethod
+    def _get_schema_config_ned_id(base_node: TNode) -> ?HTag:
+        return base_node[PTag('tlm', 'ned-id')].try_htag()
+
+class SubscriptionSourceConfig(object):
+    @property
+    config: TNode
+    @property
+    schema_settings: SchemaSettings
+
+    def __init__(self, config: TNode, schema_settings: SchemaSettings):
+        self.config = config
+        self.schema_settings = schema_settings
+
+    def __str__(self) -> str:
+        return "SubscriptionSourceConfig(config=" + optional_str(self.config, "") + ", schema_settings=" + optional_str(self.schema_settings, "") + ")"
+
+    def __repr__(self):
+        return self.__str__()
+
+class DeviceSubscriptionSourceRefiner(Refiner):
+    @property
+    subscription_source_configs: dict[Keypath, SubscriptionSourceConfig]
+    @property
+    device_to_dev_sub_keys: dict[Keypath, set[Keypath]]
+
+    def __init__(self):
+        Refiner.__init__(
+            self,
+            [],
+            [
+                DeviceSubscriptionSourceBaseRefiner.id(),
+                DeviceNedIdBaseRefiner.id()
+            ])
+
+        self.subscription_source_configs = {}
+        self.device_to_dev_sub_keys = {}
+
+    @staticmethod
+    def id() -> int:
+        return 1014
+
+    def update(self, root: TNode, input_subs: dict[SubscriptionIdentity, list[Keypath]], input_refiners: dict[int, (Refiner, list[Keypath])]) -> list[Keypath]:
+        _sub_refiner, dev_sub_keys = input_refiners[DeviceSubscriptionSourceBaseRefiner.id()]
+        _ned_id_refiner, ned_id_keys = input_refiners[DeviceNedIdBaseRefiner.id()]
+
+        updated: set[Keypath] = set(dev_sub_keys)
+
+        for device_key in ned_id_keys:
+            _dev_sub_keys = try_get(self.device_to_dev_sub_keys, device_key)
+            if _dev_sub_keys is not None:
+                set_update(updated, _dev_sub_keys)
+
+        for dev_sub_key in updated:
+            device_key = dev_sub_key.try_slice(0, 1)
+            sub_key = dev_sub_key.try_slice(1, 2)
+            if device_key is not None and sub_key is not None:
+                device_config = root[PTag('ncs', 'devices')][PTag('ncs', 'device')][device_key[0]]
+                subscription_source_node = device_config[PTag('tlm', 'telemetrify')][PTag('tlm', 'subscription')][sub_key[0]][PTag('tlm', 'source')]
+                if subscription_source_node:
+                    schema_settings = SchemaSettings.from_device_config_and_schema_config(device_config, subscription_source_node[PTag('tlm', 'schema')])
+                    self.subscription_source_configs[dev_sub_key] = SubscriptionSourceConfig(subscription_source_node, schema_settings)
+                    dict_set_add(self.device_to_dev_sub_keys, device_key, dev_sub_key)
+                else:
+                    try_pop(self.subscription_source_configs, dev_sub_key)
+                    dict_set_discard(self.device_to_dev_sub_keys, device_key, dev_sub_key)
+
+        return list(iter(updated))
+
+    def state(self, keys: Keypath) -> ?value:
+        return try_get(self.subscription_source_configs, keys)
+
+class DeviceSubscriptionSourceBaseRefiner(PassthroughRefiner):
     @property
     _workaround_actonc_issue_1598: bool
 
@@ -456,6 +682,22 @@ class DeviceSinksRefiner(Refiner):
                 if device_key in devices:
                     return try_get(self.sinks, sink_key)
         return None
+
+# class SubscriptionSinkConfig(object):
+#     @property
+#     config: TNode
+#     @property
+#     schema_settings: SchemaSettings
+
+#     def __init__(self, config: TNode, schema_settings: SchemaSettings):
+#         self.config = config
+#         self.schema_settings = schema_settings
+
+#     def __str__(self) -> str:
+#         return "SubscriptionSinkConfig(config=" + optional_str(self.config, "") + ", schema_settings=" + optional_str(self.schema_settings, "") + ")"
+
+#     def __repr__(self):
+#         return self.__str__()
 
 class DeviceSubscriptionSinkRefiner(Refiner):
     @property

--- a/src/telemetrify/main/main.act
+++ b/src/telemetrify/main/main.act
@@ -475,10 +475,11 @@ actor NetconfSource(auth: WorldCap, shared_schema: schema.SharedSchema, log_hand
     def _create_subscriber(dev_sub_key: Keypath, sub_update: SubscriptionUpdate) -> Subscriber:
         sub_config = sub_update.config
         if sub_config is not None:
-            if sub_config[SUBSCRIPTION_TYPE_KEY_ACTION_POLLER].exists():
+            _config = sub_config.config
+            if _config[SUBSCRIPTION_TYPE_KEY_ACTION_POLLER].exists():
                 sub_act = NetconfRpcPollSubscription(self, dev_sub_key, shared_schema, logh)
                 return Subscriber(sub_act.update_config, sub_act.start, sub_act.stop, sub_act.close)
-            elif sub_config[SUBSCRIPTION_TYPE_KEY_GET_POLLER].exists():
+            elif _config[SUBSCRIPTION_TYPE_KEY_GET_POLLER].exists():
                 sub_act = NetconfGetPollSubscription(self, dev_sub_key, shared_schema, logh)
                 return Subscriber(sub_act.update_config, sub_act.start, sub_act.stop, sub_act.close)
 
@@ -578,8 +579,6 @@ def _source_params_try_append_dev_sub(source_params: TNode, dev_sub_key: Keypath
         sub_name = _sub_name_key[0]
         source_params.leaf(None, PTag(None, 'subscription-name'), sub_name)
 
-#actor NetconfRpcPollSubscription(source: NetconfSource, path: str, period_ms: int):
-#actor NetconfRpcPollSubscription(source: NetconfSource, config: TNode, sinks: SubscriptionSinkCollection):
 actor NetconfRpcPollSubscription(source: NetconfSource, dev_sub_key: Keypath, shared_schema: schema.SharedSchema, log_handler: ?logging.Handler):
     var logh = logging.Handler("netconf-rpc-poll-subscription")
     if log_handler is not None:
@@ -589,9 +588,6 @@ actor NetconfRpcPollSubscription(source: NetconfSource, dev_sub_key: Keypath, sh
 
     _schema = schema.unsafe_get_shared_schema(shared_schema)
     sinks = SubscriptionSinkCollection()
-
-    #var ned_id: ?HTag = HTag(710232548, 525139965) # ('http://tail-f.com/ns/ned-id/juniper-junos-nc-4.11', 'juniper-junos-nc-4.11')  # TODO: Receive NED-ID config
-    var ned_id: ?HTag = HTag(817033024, 1122118695) # ('http://tail-f.com/ns/ned-id/ned-junos-23.1-yang-nc-1.0', 'ned-junos-23.1-yang-nc-1.0')  # TODO: Receive NED-ID config
 
     var poller_seqno: int = 0
     var rpc_xml: ?xml.Node = None
@@ -674,12 +670,13 @@ actor NetconfRpcPollSubscription(source: NetconfSource, dev_sub_key: Keypath, sh
     def update_config(update: SubscriptionUpdate):
         sinks.update(update.sinks)
 
-        _config = update.config
-        if _config is not None:
+        __config = update.config
+        if __config is not None:
+            _config: SubscriptionSourceConfig = __config
             _stop_poller()
             log.debug("SUBSCRIBER netconf-rpc-poll CONFIG", {"config": _config})
 
-            poll = _config[SUBSCRIPTION_TYPE_KEY_ACTION_POLLER]
+            poll = _config.config[SUBSCRIPTION_TYPE_KEY_ACTION_POLLER]
             path = poll[PTag('tlm', 'path')].try_str()
             period_ms = poll[PTag('tlm', 'period')].try_int()
 
@@ -688,7 +685,7 @@ actor NetconfRpcPollSubscription(source: NetconfSource, dev_sub_key: Keypath, sh
                 #_tag = schema.QName.netconf_to_value(path, None)
                 _tag = QName.netconf_to_value(path, None)
                 if _tag is not None:
-                    _update_rpc_params(Keypath([_tag]))
+                    _update_rpc_params(Keypath([_tag]), _config.schema_settings)
 
             if period_ms is not None and rpc_xml is not None:
                 period = time.Duration(period_ms // 10**3, (period_ms % 10**3) * 10**15, time.MonotonicClock(0, 0, 0))
@@ -698,7 +695,7 @@ actor NetconfRpcPollSubscription(source: NetconfSource, dev_sub_key: Keypath, sh
             else:
                 pass # TODO: Indicate config error
 
-    def _update_rpc_params(rpc_path: Keypath):
+    def _update_rpc_params(rpc_path: Keypath, schema_settings: SchemaSettings):
         _rpc_xml: ?xml.Node = None
         _is_action = False
         _schema_path: ?SchemaPath = None
@@ -710,31 +707,25 @@ actor NetconfRpcPollSubscription(source: NetconfSource, dev_sub_key: Keypath, sh
             if rpc_path_len == 1:
                 # NED-RPC
                 if cursor.push(PTag('ncs', 'rpc')):
-                    if ned_id is not None and cursor.node().is_mount_point():
-                        cursor.set_mount_id(ned_id)
+                    # Defaulting to device live-status ned-id unless explicitly set for subscription source
+                    if cursor.node().is_mount_point():
+                        ned_id = schema_settings.live_status_ned_id
+                        if ned_id is not None:
+                            cursor.set_mount_id(ned_id)
                     unmangled_rpc_tag = rpc_path[0]
                     if isinstance(unmangled_rpc_tag, PTag):
                         prefix = unmangled_rpc_tag.prefix
                         name = unmangled_rpc_tag.name
                         if cursor.push(PTag(prefix, 'rpc-' + name)) and cursor.push(unmangled_rpc_tag):
                             is_cursor_ok = True
-                        # if cursor.push(PTag(prefix, 'rpc-' + name)):
-                        #     if cursor.push(unmangled_rpc_tag):
-                        #         log.undecided("PING28", None)
-                        #         is_cursor_ok = True
-                        #     else:
-                        #         print(optional_str(cursor.lookup_ptag(cursor.node().tag), str(cursor.node().tag)))
-                        #         for c in cursor.node().children:
-                        #             print("  " + optional_str(cursor.lookup_ptag(c), str(cursor.node().tag)))
-                        # else:
-                        #     print(optional_str(cursor.lookup_ptag(cursor.node().tag), str(cursor.node().tag)))
-                        #     for c in cursor.node().children:
-                        #         print("  " + optional_str(cursor.lookup_ptag(c), str(cursor.node().tag)))
             elif rpc_path_len > 1:
                 # NED-ACTION
                 if cursor.push(PTag('ncs', 'live-status')): # TODO: Any benefit to using PTag('ncs', 'config') instead? All actions are duplicated right?
-                    if ned_id is not None and cursor.node().is_mount_point():
-                        cursor.set_mount_id(ned_id)
+                    # Defaulting to device live-status ned-id unless explicitly set for subscription source
+                    if cursor.node().is_mount_point():
+                        ned_id = schema_settings.live_status_ned_id
+                        if ned_id is not None:
+                            cursor.set_mount_id(ned_id)
                     is_cursor_ok = True
                     for _id in rpc_path:
                         if isinstance(_id, Tag) and not cursor.push(_id):
@@ -847,7 +838,8 @@ actor VManageSource(auth: WorldCap, shared_schema: schema.SharedSchema, log_hand
     def _create_subscriber(dev_sub_key: Keypath, sub_update: SubscriptionUpdate) -> Subscriber:
         sub_config = sub_update.config
         if sub_config is not None:
-            if sub_config[SUBSCRIPTION_TYPE_KEY_VMANAGE_POLLER].exists():
+            _config = sub_config.config
+            if _config[SUBSCRIPTION_TYPE_KEY_VMANAGE_POLLER].exists():
                 sub_act = VManagePollSubscription(self, dev_sub_key, shared_schema, logh)
                 return Subscriber(sub_act.update_config, sub_act.start, sub_act.stop, sub_act.close)
 
@@ -1024,7 +1016,7 @@ actor VManagePollSubscription(source: VManageSource, dev_sub_key: Keypath, share
         if _config is not None:
             _stop_poller()
 
-            poll = _config[SUBSCRIPTION_TYPE_KEY_VMANAGE_POLLER]
+            poll = _config.config[SUBSCRIPTION_TYPE_KEY_VMANAGE_POLLER]
             path = poll[PTag('tlm', 'path')].try_str()
             period_ms = poll[PTag('tlm', 'period')].try_int()
 
@@ -1034,17 +1026,22 @@ actor VManagePollSubscription(source: VManageSource, dev_sub_key: Keypath, share
                 #_tag = schema.QName.netconf_to_value(path, None)
                 _tag = QName.netconf_to_value(path, None)
                 if _tag is not None:
-                    _update_schema_cursor(Keypath([_tag]))
+                    _update_schema_cursor(Keypath([_tag]), _config.schema_settings)
 
             if period_ms is not None and poll_path is not None:
                 period = time.Duration(period_ms // 10**3, (period_ms % 10**3) * 10**15, time.MonotonicClock(0, 0, 0))
                 if is_running:
                     _try_start_poller()
 
-    def _update_schema_cursor(kpath: Keypath):
+    def _update_schema_cursor(kpath: Keypath, schema_settings: SchemaSettings):
         cursor = schema.Cursor(_schema)
         if cursor.push_schema_path(SchemaPath([PTag('ncs', 'devices'), PTag('ncs', 'device')], [])):
             if cursor.push(PTag('ncs', 'live-status')): # TODO: Any benefit to using PTag('ncs', 'config') instead? All actions are duplicated right?
+                # Defaulting to device live-status ned-id unless explicitly set for subscription source
+                if cursor.node().is_mount_point():
+                    ned_id = schema_settings.live_status_ned_id
+                    if ned_id is not None:
+                        cursor.set_mount_id(ned_id)
                 schema_path = cursor.get_schema_path()
 
     def _try_start_poller():
@@ -1080,9 +1077,6 @@ actor NetconfGetPollSubscription(source: NetconfSource, dev_sub_key: Keypath, sh
 
     _schema = schema.unsafe_get_shared_schema(shared_schema)
     sinks = SubscriptionSinkCollection()
-
-    #var ned_id: ?HTag = HTag(710232548, 525139965) # ('http://tail-f.com/ns/ned-id/juniper-junos-nc-4.11', 'http://tail-f.com/ns/ned-id/juniper-junos-nc-4.11')  # TODO: Receive NED-ID config
-    var ned_id: ?HTag = HTag(1503593780, 92759342) # ('http://tail-f.com/ns/ned-id/ned-ios-xe-yang-nc-17.11', 'ned-ios-xe-yang-nc-17.11')  # TODO: Receive NED-ID config
 
     var poller_seqno: int = 0
     var get_xml: ?xml.Node = None
@@ -1248,12 +1242,13 @@ actor NetconfGetPollSubscription(source: NetconfSource, dev_sub_key: Keypath, sh
     def update_config(update: SubscriptionUpdate):
         sinks.update(update.sinks)
 
-        _config = update.config
-        if _config is not None:
+        __config = update.config
+        if __config is not None:
+            _config: SubscriptionSourceConfig = __config
             _stop_poller()
             log.debug("SUBSCRIBER netconf-get-poll CONFIG", {"_config": _config})
 
-            poll = _config[SUBSCRIPTION_TYPE_KEY_GET_POLLER]
+            poll = _config.config[SUBSCRIPTION_TYPE_KEY_GET_POLLER]
             path = poll[PTag('tlm', 'path')].try_str()
             period_ms = poll[PTag('tlm', 'period')].try_int()
 
@@ -1262,7 +1257,7 @@ actor NetconfGetPollSubscription(source: NetconfSource, dev_sub_key: Keypath, sh
                 #_tag = schema.QName.netconf_to_value(path, None)
                 _tag = QName.netconf_to_value(path, None)
                 if _tag is not None:
-                    _update_get_params(Keypath([_tag]))
+                    _update_get_params(Keypath([_tag]), _config.schema_settings)
 
             if period_ms is not None and get_xml is not None:
                 period = time.Duration(period_ms // 10**3, (period_ms % 10**3) * 10**15, time.MonotonicClock(0, 0, 0))
@@ -1272,7 +1267,7 @@ actor NetconfGetPollSubscription(source: NetconfSource, dev_sub_key: Keypath, sh
             else:
                 pass # TODO: Indicate config error
 
-    def _update_get_params(get_path: Keypath):
+    def _update_get_params(get_path: Keypath, schema_settings: SchemaSettings):
         _get_xml: ?xml.Node = None
         _is_action = False
         _schema_path: ?SchemaPath = None
@@ -1284,8 +1279,11 @@ actor NetconfGetPollSubscription(source: NetconfSource, dev_sub_key: Keypath, sh
 
             # NED-GET
             if cursor.push(PTag('ncs', 'live-status')):
-                if ned_id is not None and cursor.node().is_mount_point():
-                    cursor.set_mount_id(ned_id)
+                # Defaulting to device live-status ned-id unless explicitly set for subscription source
+                if cursor.node().is_mount_point():
+                    ned_id = schema_settings.live_status_ned_id
+                    if ned_id is not None:
+                        cursor.set_mount_id(ned_id)
                 is_cursor_ok = True
                 for _id in get_path:
                     if isinstance(_id, Tag) and not cursor.push(_id):
@@ -1364,7 +1362,7 @@ actor NetconfGetPollSubscription(source: NetconfSource, dev_sub_key: Keypath, sh
 
 class SubscriptionUpdate(object):
     @property
-    config: ?TNode
+    config: ?SubscriptionSourceConfig
     @property
     sinks: list[(Keypath, ?SubscriptionSink)]
 
@@ -1438,11 +1436,12 @@ actor DeviceStreamer(env: Env, name: str, shared_schema: schema.SharedSchema, sh
 
         # Prepare subscriptions
         for dev_sub_key, state in subscription_updates:
-            if state is not None and isinstance(state, TNode):
-                source_key = _get_subscription_source_key(state)
+            if state is not None and isinstance(state, SubscriptionSourceConfig):
+                config: SubscriptionSourceConfig = state
+                source_key = _get_subscription_source_key(config.config)
                 subscription_sources[dev_sub_key] = source_key
                 sub_update = get_or_create(dev_sub_updates, dev_sub_key, SubscriptionUpdate)
-                sub_update.config = state
+                sub_update.config = config
                 dict_set_add(updated_source_dev_sub_keys, source_key, dev_sub_key)
             else:
                 source_key = try_pop(subscription_sources, dev_sub_key)
@@ -1473,15 +1472,15 @@ actor DeviceStreamer(env: Env, name: str, shared_schema: schema.SharedSchema, sh
                 source.close()
                 del sources[source_key]
 
-    def _get_subscription_source_key(state: TNode) -> Keypath:
-        if state[SUBSCRIPTION_TYPE_KEY_ACTION_POLLER].exists():
+    def _get_subscription_source_key(config: TNode) -> Keypath:
+        if config[SUBSCRIPTION_TYPE_KEY_ACTION_POLLER].exists():
             return SOURCE_KEY_NETCONF
-        if state[SUBSCRIPTION_TYPE_KEY_GET_POLLER].exists():
+        if config[SUBSCRIPTION_TYPE_KEY_GET_POLLER].exists():
             return SOURCE_KEY_NETCONF
-        if state[SUBSCRIPTION_TYPE_KEY_VMANAGE_POLLER].exists():
+        if config[SUBSCRIPTION_TYPE_KEY_VMANAGE_POLLER].exists():
             return SOURCE_KEY_VMANAGE_HTTP
 
-        raise Exception("Unknown subscription type: " + str(state))
+        raise Exception("Unknown subscription type: " + str(config))
 
     def _get_or_create_source(source_key: Keypath) -> Source:
         _source = try_get(sources, source_key)
@@ -1637,10 +1636,12 @@ actor main(env):
         cache = telemetrify.nso.subscriber.CdbCache(sc, cc, s,
             [
                 DeviceSettingsRefiner,
+                DeviceNedIdBaseRefiner,
+                DeviceStreamerRefiner,
                 DeviceSourceNetconfRefiner,
                 DeviceSourceVmanageRefiner,
                 DeviceSourceRefiner,
-                DeviceStreamerRefiner,
+                DeviceSubscriptionSourceBaseRefiner,
                 DeviceSubscriptionSourceRefiner,
                 DeviceSubscriptionSinkBaseRefiner,
                 DeviceSubscriptionSinkRefiner,
@@ -1650,10 +1651,12 @@ actor main(env):
             ],
             [([
                 #DeviceSettingsRefiner.id(), # For DEBUG printouts only
+                #DeviceNedIdBaseRefiner.id(), # For DEBUG printouts only
                 DeviceStreamerRefiner.id(),
                 #DeviceSourceNetconfRefiner.id(), # For DEBUG printouts only
                 #DeviceSourceVmanageRefiner.id(), # For DEBUG printouts only
                 DeviceSourceRefiner.id(),
+                #DeviceSubscriptionSourceBaseRefiner.id(), # For DEBUG printouts only
                 DeviceSubscriptionSourceRefiner.id(),
                 #DeviceSubscriptionSinkBaseRefiner.id(), # For DEBUG printouts purposes
                 DeviceSubscriptionSinkRefiner.id(),

--- a/telemetrify-nso/packages/telemetrify/src/yang/telemetrify.yang
+++ b/telemetrify-nso/packages/telemetrify/src/yang/telemetrify.yang
@@ -19,6 +19,10 @@ module telemetrify {
     prefix ncs;
   }
 
+  import tailf-ncs-ned {
+    prefix ned;
+  }
+
   description
       "Telemetry streaming implemented in Acton";
 
@@ -99,6 +103,13 @@ module telemetrify {
             }
           }
 
+          container schema {
+            description "Schema settings for source (pre-transform).";
+            when "../netconf-rpc-poll
+                or ../netconf-get-poll";
+            uses schema-settings-g;
+          }
+
           // TODO: Transform at source
           // uses transform-g;
         }
@@ -148,7 +159,13 @@ module telemetrify {
           // Per sink transform
           uses transform-g;
 
-          // Moar params? Translations, default namespaces etc...
+          // TODO
+          // container schema {
+          //   description "Schema settings for sink (post-transform).";
+          //   uses schema-settings-g;
+          // }
+
+          // Moar params? default namespaces etc...
         }
       }
 
@@ -222,6 +239,18 @@ module telemetrify {
         type string;
       }
       // TODO: Transformation language?
+    }
+  }
+
+  grouping schema-settings-g {
+    leaf ned-id {
+      description
+        "Override ned-id otherwise gathered from /devices/device/device-type/*/ned-id or from
+        /devices/device/live-status-protocol/device-type/*/ned-id.";
+
+      type identityref {
+        base ned:ned-id;
+      }
     }
   }
 


### PR DESCRIPTION
Use ned-id configured for device i.e:  
  /devices/device/device-type/ned-id
  or
    /devices/device/live-status-protocol/ned-id
  unless specified for subscription at
    /devices/device/telemetrify/subscription/source/schema/ned-id