### PR TITLE
Unified state management for device/source/subscriptions actors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,9 @@ jobs:
       - name: "Build"
         run: |
           actonc build
+      - name: "Test"
+        run: |
+          make test
 
 #  test-macos:
 #    runs-on: macos-12

--- a/Makefile
+++ b/Makefile
@@ -44,12 +44,20 @@ clean:
 
 run-nogc:
 	GC_DONT_GC=1 $(OUTPUT)/bin/$(BIN) $(ARGS)
+.PHONY: run-nogc
 
 run:
 	$(OUTPUT)/bin/$(BIN) $(ARGS)
+.PHONY: run
 
 debug-nogc:
 	gdb -ex 'handle SIGPWR SIGXCPU nostop noprint' -ex 'set env GC_DONT_GC=1' --args $(OUTPUT)/bin/$(BIN) --rts-wthreads 1 $(ARGS)
+.PHONY: debug-nogc
 
 debug:
 	gdb -ex 'handle SIGPWR SIGXCPU nostop noprint' --args $(OUTPUT)/bin/$(BIN) --rts-wthreads 1 $(ARGS)
+.PHONY: debug
+
+test:
+	$(OUTPUT)/bin/telemetrify.main.test.common
+.PHONY: test

--- a/src/telemetrify/common/mod.act
+++ b/src/telemetrify/common/mod.act
@@ -33,7 +33,7 @@ def op_str(op: int) -> str:
     elif op == OP_NOCREATE:
         return "NOCREATE"
     else:
-        raise Exception("Not Implemented")
+        raise Exception("Not Implemented for op: " + str(op))
 
 class Id:
     def __repr__(self):
@@ -1380,7 +1380,7 @@ extension Id(Hashable):
         elif isinstance(self, Key) and isinstance(other, Key):
             return self == other
         else:
-            raise Exception("Id.__eq__: Not Implemented")
+            raise Exception("Id.__eq__: Not Implemented for types " + str(type(self)) + " == " + str(type(other)))
 
     def __hash__(self):
         if isinstance(self, Tag):
@@ -1388,7 +1388,7 @@ extension Id(Hashable):
         elif isinstance(self, Key):
             return hash(self)
         else:
-            raise Exception("Id.__hash__: Not Implemented")
+            raise Exception("Id.__hash__: Not Implemented for type: " + type(self))
 
 extension Tag(Hashable):
     def __eq__(self, other: Id):
@@ -1401,7 +1401,7 @@ extension Tag(Hashable):
         elif isinstance(self, HTag) and isinstance(other, HTag):
             return self == other
         else:
-            raise Exception("Tag.__eq__: Not Implemented")
+            raise Exception("Tag.__eq__: Not Implemented for types " + str(type(self)) + " == " + str(type(other)))
 
     def __hash__(self):
         if isinstance(self, ITag):
@@ -1413,7 +1413,7 @@ extension Tag(Hashable):
         elif isinstance(self, HTag):
             return hash(self)
         else:
-            raise Exception("Tag.__hash__: Not Implemented")
+            raise Exception("Tag.__hash__: Not Implemented for type: " + type(self))
 
 extension Keypath(Hashable):
     def __eq__(self, other) -> bool:

--- a/src/telemetrify/common/utils.act
+++ b/src/telemetrify/common/utils.act
@@ -359,6 +359,25 @@ def dict_set_discard[K(Hashable), V(Hashable)](d: dict[K, set[V]], k: K, v: V):
         if len(s) == 0:
             del d[k]
 
+def dict_dict_add[K1(Hashable), K2(Hashable), V](d1: dict[K1, dict[K2, V]], k1: K1, k2: K2, v: V):
+    try:
+        d2 = d1[k1]
+    except KeyError:
+        d1[k1] = {k2: v}
+    else:
+        d2[k2] = v
+
+def dict_dict_try_pop[K1(Hashable), K2(Hashable), V](d1: dict[K1, dict[K2, V]], k1: K1, k2: K2) -> ?V:
+    try:
+        d2 = d1[k1]
+    except KeyError:
+        return None
+    else:
+        v = try_pop(d2, k2)
+        if not bool(d2):
+            del d1[k1]
+        return v
+
 def optional_str[T](v: ?T, default: str) -> str:
     return str(v) if v is not None else default
 
@@ -534,11 +553,19 @@ class Wardrobe[T](object):
         del self.items[ticket]
         return item
 
+    def pop_all(self):
+        items = self.items
+        self.items = {}
+        return items.items()
+
     def discard(self, ticket):
         try:
             del self.items[ticket]
         except KeyError:
             pass
+
+    def get_tickets(self):
+        return self.items.keys()
 
     def clear(self):
         #self.items.clear()

--- a/src/telemetrify/ietf/cat8k.act
+++ b/src/telemetrify/ietf/cat8k.act
@@ -43,7 +43,7 @@ class OnewayStats(object):
         self.packet_loss = packet_loss
 
 actor IpSlaTransform(
-        output_cb: action(Node, TNode) -> None,
+        output_cb: action(Node, TNode, ?action() -> None) -> None,
         fetch_l3vpn_svc_tracker: action(action(telemetrify.ietf.l3vpn_svc.L3vpnSvcTracker) -> None) -> None,
         release_l3vpn_svc_tracker: action(telemetrify.ietf.l3vpn_svc.L3vpnSvcTracker) -> None,
         log_handler: ?logging.Handler):
@@ -53,11 +53,20 @@ actor IpSlaTransform(
         logh.set_handler(log_handler)
     var log = logging.Logger(logh)
 
-    tasks: Wardrobe[(IpSlaStats, TNode)] = Wardrobe()
+    tasks: Wardrobe[(IpSlaStats, TNode, ?action() -> None)] = Wardrobe()
     l3vpn_svc_tracker: ?telemetrify.ietf.l3vpn_svc.L3vpnSvcTracker = None
     pending_fetch_l3vpn_svc_tracker_task_ids: list[int] = []
 
-    def transform(node: Node, source_params: TNode):
+    def transform(node: Node, source_params: TNode, done_cb: ?action() -> None):
+        is_reset = source_params.has_child(PTag(None, 'reset'))
+        if is_reset:
+            _transform_reset(node, source_params, done_cb)
+        else:
+            _transform_update(node, source_params, done_cb)
+
+    def _transform_update(node: Node, source_params: TNode, done_cb: ?action() -> None):
+        log.debug("Transform update", None)
+
         src_ns = "http://cisco.com/ns/yang/Cisco-IOS-XE-ip-sla-oper"
 
         hostname = source_params[PTag(None, 'device-name')].try_str()
@@ -178,7 +187,7 @@ actor IpSlaTransform(
                         target_addresses.add(target_address)
                         links[target_address] = link_stats
 
-                task_id = tasks.put((IpSlaStats(hostname, links), source_params))
+                task_id = tasks.put((IpSlaStats(hostname, links), source_params, done_cb))
 
                 _l3vpn_svc_tracker = l3vpn_svc_tracker
                 if _l3vpn_svc_tracker is not None:
@@ -190,12 +199,18 @@ actor IpSlaTransform(
         else:
             log.warning("Missing source_params 'device-name'", None)
 
+    def _transform_reset(node: Node, source_params: TNode, done_cb: ?action() -> None):
+        log.debug("Transform reset", None)
+        # TODO: ...
+        if done_cb is not None:
+            done_cb()
+
     def _on_lookup_result(hostnames_lookup: dict[str, L3vpnSvcParams], ipv4_addresses_lookup: dict[IPv4Address, L3vpnSvcParams], task_id: int):
 
         log.debug("lookup", {"hostnames": mapping_str(hostnames_lookup), "ipv4_addresses": mapping_str(ipv4_addresses_lookup)})
 
         try:
-            _ip_sla_stats, source_params = tasks.pop(task_id)
+            _ip_sla_stats, source_params, done_cb = tasks.pop(task_id)
         except KeyError:
             pass # TODO: debug/trace log?
         else:
@@ -218,7 +233,7 @@ actor IpSlaTransform(
             # if log.output_level >= logging.TRACE:
             #     log.trace("output", root.pretty_format_node_tree())
 
-            output_cb(root, source_params)
+            output_cb(root, source_params, done_cb)
 
     def _create_network_node(root, src_svc: L3vpnSvcParams, src_stats: ?OnewayStats, dst_svc: ?L3vpnSvcParams):
         ns = "urn:ietf:params:xml:ns:yang:ietf-network-state"
@@ -302,7 +317,7 @@ actor IpSlaTransform(
         l3vpn_svc_tracker = _l3vpn_svc_tracker
         for task_id in pending_fetch_l3vpn_svc_tracker_task_ids:
             try:
-                _ip_sla_stats, source_params = tasks.borrow(task_id)
+                _ip_sla_stats, source_params, _done_cb = tasks.borrow(task_id)
             except KeyError:
                 pass # TODO: debug/trace log?
             else:

--- a/src/telemetrify/main/common.act
+++ b/src/telemetrify/main/common.act
@@ -1,3 +1,18 @@
+# Copyright (C) Deutsche Telekom AG
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+import telemetrify.common.utils as utils
+
 from telemetrify.common.mod import *
 from telemetrify.common.utils import *
 
@@ -7,26 +22,390 @@ def tnode_empty() -> TNode:
 def tnode_root() -> TNode:
     return TTree(OP_NONE, PTag.root(), None, {})
 
+SOURCE_PARAM_TIMESTAMP = PTag(None, 'timestamp')
+SOURCE_PARAM_SCHEMA_PATH = PTag(None, 'schema_path')
+SOURCE_PARAM_BASE_TAGS = PTag(None, 'base_tags')
+SOURCE_PARAM_RESET = PTag(None, 'reset')
+
+# STATE_NONE = 0
+STATE_STOPPED = 1 # valid target-/externally-visible- state
+STATE_STARTING = 2 # internal transition only, i.e. not a valid target-state
+STATE_RUNNING = 3 # valid target-/externally-visible- state
+STATE_RESTARTING = 5 # internal transition only, i.e. not a valid target-state
+STATE_STOPPING = 6 # internal transition only, i.e. not a valid target-state
+STATE_CLOSING = 8 # internal transition only, i.e. not a valid target-state
+STATE_CLOSED = 9 # valid target-/externally-visible- state
+
+def state_str(state: int) -> str:
+    # if state == STATE_NONE:
+    #     return "NONE"
+    if state == STATE_STOPPED:
+        return "STOPPED"
+    elif state == STATE_STARTING:
+        return "STARTING"
+    elif state == STATE_RUNNING:
+        return "RUNNING"
+    elif state == STATE_RESTARTING:
+        return "RESTARTING"
+    if state == STATE_STOPPING:
+        return "STOPPING"
+    elif state == STATE_CLOSING:
+        return "CLOSING"
+    elif state == STATE_CLOSED:
+        return "CLOSED"
+    raise ValueError("Unknown state value: " + str(state))
+
+class DelegateId:
+    @property
+    key: Keypath
+    @property
+    seqno: int
+
+    def __init__(self, key: Keypath, seqno: int):
+        self.key = key
+        self.seqno = seqno
+
+    def __repr__(self) -> str:
+        return "DelegateId(" + str(self.key) + ", " + str(self.seqno) + ")"
+
+    def __str__(self) -> str:
+        return self.__repr__()
+
+extension DelegateId(Hashable):
+    def __eq__(self, other):
+        return self.seqno == other.seqno and self.key == other.key
+
+    def __hash__(self):
+        return safe_hash(hash(self.key) + 4001 * hash(self.seqno))
+
+protocol Delegate:
+    set_target_state: action(int) -> None
+
+class DelegateData[T(Delegate)](object):
+    @property
+    identity: DelegateId
+    @property
+    delegate: T
+    @property
+    target_state: int
+
+    def __init__(self, identity: DelegateId, delegate: T):
+        self.identity = identity
+        self.delegate = delegate
+        self.target_state = STATE_STOPPED
+
+class DelegateManager[T(Delegate)](object):
+    @property
+    _delegates: dict[Keypath, DelegateData[T]]
+    @property
+    _pending_close: dict[Keypath, dict[DelegateId, T]]
+    @property
+    _pending_state_transition: set[DelegateId]
+    @property
+    _next_seqno: int
+    @property
+    _target_state: int
+    @property
+    _on_delegate_reached_state_trampoline_fn: action(DelegateId, int) -> None
+    @property
+    _on_joint_state_cb: proc(int) -> None
+
+    def __init__(self,
+            on_delegate_reached_state_trampoline_fn: action(DelegateId, int) -> None,
+            on_joint_state_cb: proc(int) -> None):
+
+        self._delegates = {}
+        self._pending_close = {}
+        self._pending_state_transition = set([])
+        self._next_seqno = 0
+        self._target_state = STATE_STOPPED
+        self._on_delegate_reached_state_trampoline_fn = on_delegate_reached_state_trampoline_fn
+        self._on_joint_state_cb = on_joint_state_cb
+
+def DelegateManager_try_get[T(Delegate)](self: DelegateManager[T], key: Keypath) -> ?T:
+    delegate_data = utils.try_get(self._delegates, key)
+    if delegate_data is not None:
+        return delegate_data.delegate
+    return None
+
+def DelegateManager_reserve[T(Delegate)](self: DelegateManager[T], key: Keypath) -> (DelegateId, action(int) -> None):
+    delegate_id = DelegateId(key, self._next_seqno)
+    self._next_seqno += 1
+
+    def wrapper(state: int) -> None:
+        self._on_delegate_reached_state_trampoline_fn(delegate_id, state)
+
+    return (delegate_id, wrapper)
+
+def DelegateManager_get_target_state[T(Delegate)](self: DelegateManager[T]) -> int:
+    return self._target_state
+
+def DelegateManager_set_target_state[T(Delegate)](self: DelegateManager[T], target_state: int):
+    if self._target_state != target_state:
+        self._target_state = target_state
+        for delegate_data in list(self._delegates.values()):
+            DelegateManager__update_delegate_target_state(self, delegate_data, self._target_state)
+    DelegateManager__evaluate_settled_delegate_state(self)
+
+def DelegateManager__update_delegate_target_state[T(Delegate)](self: DelegateManager[T], delegate_data: DelegateData[T], target_state: int):
+    if delegate_data.target_state != target_state:
+        if target_state == STATE_RUNNING and delegate_data.identity.key in self._pending_close:
+            delegate_data.target_state = target_state
+        else:
+            DelegateManager__set_delegate_target_state(self, delegate_data, target_state)
+
+def DelegateManager__set_delegate_target_state[T(Delegate)](self: DelegateManager[T], delegate_data: DelegateData[T], target_state: int):
+    delegate_data.target_state = target_state
+    if target_state == STATE_CLOSED:
+        utils.try_pop(self._delegates, delegate_data.identity.key)
+        dict_dict_add(self._pending_close, delegate_data.identity.key, delegate_data.identity, delegate_data.delegate)
+    self._pending_state_transition.add(delegate_data.identity)
+    delegate_data.delegate.set_target_state(target_state)
+
+def DelegateManager__evaluate_settled_delegate_state[T(Delegate)](self: DelegateManager[T]):
+    if not self._pending_state_transition:
+        self._on_joint_state_cb(self._target_state)
+
+def DelegateManager_on_delegate_reached_state[T(Delegate)](self: DelegateManager[T], delegate_id: DelegateId, state: int):
+    self._pending_state_transition.discard(delegate_id)
+    if state == STATE_CLOSED:
+        dict_dict_try_pop(self._pending_close, delegate_id.key, delegate_id)
+        if delegate_id.key not in self._pending_close:
+            successor_delegate_data = utils.try_get(self._delegates, delegate_id.key)
+            if successor_delegate_data is not None:
+                DelegateManager__set_delegate_target_state(self, successor_delegate_data, successor_delegate_data.target_state)
+    else:
+        delegate_data = utils.try_get(self._delegates, delegate_id.key)
+        if delegate_data is not None and state != delegate_data.target_state:
+            DelegateManager__update_delegate_target_state(self, delegate_data, delegate_data.target_state)
+    DelegateManager__evaluate_settled_delegate_state(self)
+
+def DelegateManager_add[T(Delegate)](self: DelegateManager[T], delegate_id: DelegateId, delegate: T, setup_fn: proc(T) -> None):
+    DelegateManager_remove(self, delegate_id.key)
+    delegate_data = DelegateData(delegate_id, delegate)
+    self._delegates[delegate_id.key] = delegate_data
+    setup_fn(delegate)
+    DelegateManager__update_delegate_target_state(self, delegate_data, self._target_state)
+
+def DelegateManager_remove[T(Delegate)](self: DelegateManager[T], key: Keypath):
+    delegate_data = utils.try_pop(self._delegates, key)
+    if delegate_data is not None:
+        DelegateManager__set_delegate_target_state(self, delegate_data, STATE_CLOSED)
+
+class DelegateMiddleManager[T(Delegate)](object):
+    @property
+    target_state: int
+    @property
+    current_state: int
+    @property
+    _delegate_manager: DelegateManager[T]
+    @property
+    _start_fn: proc() -> None
+    @property
+    _stop_fn: proc() -> None
+    @property
+    _reached_state_cb: action(int) -> None
+
+    def __init__(self,
+            reached_state_cb: action(int) -> None,
+            on_delegate_reached_state_trampoline_fn: action(DelegateId, int) -> None,
+            start_inner_fn: ?proc() -> None,
+            stop_inner_fn: ?proc() -> None):
+
+        self.target_state = STATE_STOPPED
+        self.current_state = STATE_STOPPED
+        self._delegate_manager = DelegateManager(on_delegate_reached_state_trampoline_fn, lambda s: DelegateMiddleManager__on_delegates_joint_state(self, s))
+
+        self._start_fn = start_inner_fn if start_inner_fn is not None else lambda: DelegateMiddleManager_on_inner_started(self)
+        self._stop_fn = stop_inner_fn if stop_inner_fn is not None else lambda: DelegateMiddleManager_on_inner_stopped(self)
+        self._reached_state_cb = reached_state_cb
+
+def DelegateMiddleManager_on_inner_started[T(Delegate)](self: DelegateMiddleManager[T]):
+    if self.current_state == STATE_STARTING:
+        self.current_state = STATE_RUNNING
+        self._reached_state_cb(STATE_RUNNING)
+        DelegateManager_set_target_state(self._delegate_manager, STATE_RUNNING)
+    else:
+        self._stop_fn()
+
+def DelegateMiddleManager_on_inner_stopped[T(Delegate)](self: DelegateMiddleManager[T]):
+    if self.current_state == STATE_RESTARTING:
+        self.current_state = STATE_STARTING
+        self._start_fn()
+    elif self.current_state == STATE_STOPPING:
+        self.current_state = STATE_STOPPED
+        self._reached_state_cb(STATE_STOPPED)
+    elif self.current_state == STATE_CLOSING:
+        self.current_state = STATE_CLOSED
+        self._reached_state_cb(STATE_CLOSED)
+
+def DelegateMiddleManager_try_restart_inner[T(Delegate)](self: DelegateMiddleManager[T]):
+    if self.current_state in [STATE_RUNNING, STATE_STARTING]:
+        self.current_state = STATE_RESTARTING
+        DelegateManager_set_target_state(self._delegate_manager, STATE_STOPPED)
+
+def DelegateMiddleManager_set_target_state[T(Delegate)](self: DelegateMiddleManager[T], target_state: int) -> bool:
+    self.target_state = target_state
+
+    if self.current_state == self.target_state:
+        self._reached_state_cb(target_state)
+        return True
+
+    elif self.current_state == STATE_CLOSED or self.current_state == STATE_CLOSING and target_state != STATE_CLOSED:
+        return False
+
+    if target_state == STATE_CLOSED:
+        if self.current_state == STATE_STOPPED:
+            self.current_state = STATE_CLOSED
+            self._reached_state_cb(target_state)
+        elif self.current_state in [STATE_STOPPING, STATE_RESTARTING]:
+            self.current_state = STATE_CLOSING
+        else:
+            self.current_state = STATE_CLOSING
+            DelegateManager_set_target_state(self._delegate_manager, STATE_CLOSED)
+        return True
+    elif target_state == STATE_RUNNING:
+        if self.current_state == STATE_STOPPING:
+            self.current_state = STATE_RESTARTING
+        elif self.current_state == STATE_STOPPED:
+            self.current_state = STATE_STARTING
+            self._start_fn()
+        return True
+    elif target_state == STATE_STOPPED:
+        self.current_state = STATE_STOPPING
+        DelegateManager_set_target_state(self._delegate_manager, STATE_STOPPED)
+        return True
+
+    return False
+
+def DelegateMiddleManager__on_delegates_joint_state[T(Delegate)](self: DelegateMiddleManager[T], state: int):
+    if state == STATE_CLOSED:
+        if self.current_state == STATE_CLOSING:
+            self._stop_fn()
+    elif state == STATE_STOPPED:
+        if self.current_state in [STATE_RESTARTING, STATE_STOPPING, STATE_CLOSING]:
+            self._stop_fn()
+
+def DelegateMiddleManager_try_get_delegate[T(Delegate)](self: DelegateMiddleManager[T], key: Keypath) -> ?T:
+    return DelegateManager_try_get(self._delegate_manager, key)
+
+def DelegateMiddleManager_reserve_delegate[T(Delegate)](self: DelegateMiddleManager[T], key: Keypath) -> (DelegateId, action(int) -> None):
+    return DelegateManager_reserve(self._delegate_manager, key)
+
+def DelegateMiddleManager_add_delegate[T(Delegate)](self: DelegateMiddleManager[T], delegate_id: DelegateId, delegate: T, setup_fn: proc(T) -> None):
+    DelegateManager_add(self._delegate_manager, delegate_id, delegate, setup_fn)
+
+def DelegateMiddleManager_remove_delegate[T(Delegate)](self: DelegateMiddleManager[T], key: Keypath):
+    DelegateManager_remove(self._delegate_manager, key)
+
+def DelegateMiddleManager_on_delegate_reached_state[T(Delegate)](self: DelegateMiddleManager[T], delegate_id: DelegateId, state: int):
+    DelegateManager_on_delegate_reached_state(self._delegate_manager, delegate_id, state)
+
+class DelegateWorker(object):
+    @property
+    target_state: int
+    @property
+    current_state: int
+    @property
+    _start_fn: proc() -> None
+    @property
+    _stop_fn: proc() -> None
+    @property
+    _reached_state_cb: action(int) -> None
+
+    def __init__(self,
+            reached_state_cb: action(int) -> None,
+            start_inner_fn: ?proc() -> None,
+            stop_inner_fn: ?proc() -> None):
+
+        self.target_state = STATE_STOPPED
+        self.current_state = STATE_STOPPED
+
+        self._start_fn = start_inner_fn if start_inner_fn is not None else lambda: DelegateWorker_on_inner_started(self)
+        self._stop_fn = stop_inner_fn if stop_inner_fn is not None else lambda: DelegateWorker_on_inner_stopped(self)
+        self._reached_state_cb = reached_state_cb
+
+def DelegateWorker_on_inner_started(self: DelegateWorker):
+    if self.current_state == STATE_STARTING:
+        self.current_state = STATE_RUNNING
+        self._reached_state_cb(STATE_RUNNING)
+    elif self.current_state in [STATE_STOPPING, STATE_CLOSING]:
+        self._stop_fn()
+
+def DelegateWorker_on_inner_stopped(self: DelegateWorker):
+    if self.current_state == STATE_RESTARTING:
+        self.current_state = STATE_STARTING
+        # self._reached_state_cb(STATE_STOPPED) # Show the 'internal' stop-to-restart?
+        self._start_fn()
+    elif self.current_state == STATE_STOPPING:
+        self.current_state = STATE_STOPPED
+        self._reached_state_cb(STATE_STOPPED)
+    elif self.current_state == STATE_CLOSING:
+        self.current_state = STATE_CLOSED
+        self._reached_state_cb(STATE_CLOSED)
+
+def DelegateWorker_try_restart_inner(self: DelegateWorker):
+    if self.current_state in [STATE_RUNNING, STATE_STARTING]:
+        self.current_state = STATE_RESTARTING
+        self._stop_fn()
+
+def DelegateWorker_set_target_state(self: DelegateWorker, target_state: int) -> bool:
+    self.target_state = target_state
+
+    if self.current_state == self.target_state:
+        self._reached_state_cb(target_state)
+        return True
+
+    elif self.current_state == STATE_CLOSED or self.current_state == STATE_CLOSING and target_state != STATE_CLOSED:
+        return False
+
+    if target_state == STATE_RUNNING:
+        if self.current_state == STATE_STOPPING:
+            self.current_state = STATE_RESTARTING
+        elif self.current_state == STATE_STOPPED:
+            self.current_state = STATE_STARTING
+            self._start_fn()
+        return True
+    elif target_state == STATE_STOPPED:
+        if self.current_state == STATE_RESTARTING:
+            self.current_state = STATE_STOPPING
+        else:
+            self.current_state = STATE_STOPPING
+            self._stop_fn()
+        return True
+    elif target_state == STATE_CLOSED:
+        if self.current_state == STATE_STOPPED:
+            self.current_state = STATE_CLOSED
+            self._reached_state_cb(target_state)
+        elif self.current_state in [STATE_STOPPING, STATE_RESTARTING]:
+            self.current_state = STATE_CLOSING
+        else:
+            self.current_state = STATE_CLOSING
+            self._stop_fn()
+        return True
+
+    return False
+
 #
 # Sink
 #
 
 class Sink(object):
     @property
-    write_fn: action(Node, TNode, TNode) -> None
+    write_fn: action(Node, TNode, TNode, ?action() -> None) -> None
     @property
     close_fn: action() -> None
 
     def __init__(
             self,
-            write_fn: action(Node, TNode, TNode) -> None,
+            write_fn: action(Node, TNode, TNode, ?action() -> None) -> None,
             close_fn: action() -> None,
             ):
         self.write_fn = write_fn
         self.close_fn = close_fn
 
-    def write(self, node: Node, source_params: TNode, sink_config: TNode) -> None:
-        self.write_fn(node, source_params, sink_config)
+    def write(self, node: Node, source_params: TNode, sink_config: TNode, done_cb: ?action() -> None) -> None:
+        self.write_fn(node, source_params, sink_config, done_cb)
 
     def close(self):
         self.close_fn()
@@ -36,21 +415,19 @@ class Sink(object):
 
 class Source(object):
     @property
-    update_config_fn: action(?TNode, list[(Keypath, ?SubscriptionUpdate)]) -> None
+    set_target_state_fn: action(int) -> None
     @property
-    close_fn: action() -> None
+    update_config_fn: action(?TNode, list[(Keypath, ?SubscriptionUpdate)]) -> None
     @property
     subscription_keys: set[Keypath]
 
     def __init__(
             self,
-            key: Keypath,
-            update_config_fn: action(?TNode, list[(Keypath, ?SubscriptionUpdate)]) -> None,
-            close_fn: action() -> None
-            ):
-        self.key = key
+            set_target_state_fn: action(int) -> None,
+            update_config_fn: action(?TNode, list[(Keypath, ?SubscriptionUpdate)]) -> None):
+
+        self.set_target_state_fn = set_target_state_fn
         self.update_config_fn = update_config_fn
-        self.close_fn = close_fn
         self.subscription_keys = set([])
 
     def has_subscriptions(self) -> bool:
@@ -65,8 +442,9 @@ class Source(object):
 
         self.update_config_fn(source_update, subscription_updates)
 
-    def close(self):
-        self.close_fn()
+extension Source(Delegate):
+    def set_target_state(self, target_state: int) -> None:
+        self.set_target_state_fn(target_state)
 
 #
 # Subscription
@@ -74,37 +452,24 @@ class Source(object):
 
 class Subscriber(object):
     @property
+    set_target_state_fn: action(int) -> None
+    @property
     update_config_fn: action(SubscriptionUpdate) -> None
-    @property
-    start_fn: action() -> None
-    @property
-    stop_fn: action() -> None
-    @property
-    close_fn: action() -> None
 
     def __init__(
             self,
-            update_config_fn: action(SubscriptionUpdate) -> None,
-            start_fn: action() -> None,
-            stop_fn: action() -> None,
-            close_fn: action() -> None
-            ):
+            set_target_state_fn: action(int) -> None,
+            update_config_fn: action(SubscriptionUpdate) -> None):
+
+        self.set_target_state_fn = set_target_state_fn
         self.update_config_fn = update_config_fn
-        self.start_fn = start_fn
-        self.stop_fn = stop_fn
-        self.close_fn = close_fn
 
     def update_config(self, update: SubscriptionUpdate):
         self.update_config_fn(update)
 
-    def start(self):
-        self.start_fn()
-
-    def stop(self):
-        self.stop_fn()
-
-    def close(self):
-        self.close_fn()
+extension Subscriber(Delegate):
+    def set_target_state(self, target_state: int) -> None:
+        self.set_target_state_fn(target_state)
 
 class SubscriptionSink(object):
     @property
@@ -114,9 +479,9 @@ class SubscriptionSink(object):
     @property
     transforms: list[Transform]
     @property
-    head_cb: action(Node, TNode) -> None
+    head_cb: action(Node, TNode, ?action() -> None) -> None
 
-    def __init__(self, config: TNode, sink: Sink, transforms: list[Transform], head_cb: action(Node, TNode) -> None):
+    def __init__(self, config: TNode, sink: Sink, transforms: list[Transform], head_cb: action(Node, TNode, ?action() -> None) -> None):
         self.config = config
         self.sink = sink
         self.transforms = transforms
@@ -128,14 +493,25 @@ class SubscriptionSink(object):
     def __repr__(self):
         return self.__str__()
 
-    def write(self, node: Node, source_params: TNode) -> None:
-        self.head_cb(node, source_params)
+    def write(self, node: Node, source_params: TNode, done_cb: ?action() -> None) -> None:
+        self.head_cb(node, source_params, done_cb)
 
     def close(self):
         # Close transforms but NOT sink as it's owned by DeviceStreamer
         for transform in self.transforms:
             transform.close()
         self.transforms.clear()
+
+actor CountDoneCallbackCollector(total_count: int, all_done_cb: action() -> None):
+    var curr_count: int = 0
+
+    def on_one_done():
+        curr_count += 1
+        if curr_count == total_count:
+            all_done_cb()
+
+    if total_count <= 0:
+        all_done_cb()
 
 class SubscriptionSinkCollection(object):
     @property
@@ -144,17 +520,29 @@ class SubscriptionSinkCollection(object):
     def __init__(self):
         self.sub_sinks = {}
 
-    def update(self, sink_updates: list[(Keypath, ?SubscriptionSink)]):
+    def update_added(self, sink_updates: list[(Keypath, ?SubscriptionSink)]):
         for sink_key, sink in sink_updates:
             if sink is not None:
                 self.sub_sinks[sink_key] = sink
                 # TODO: Signal resync where needed for differential/delta subscriptions?
-            else:
+
+    def update_removed(self, sink_updates: list[(Keypath, ?SubscriptionSink)]):
+        for sink_key, sink in sink_updates:
+            if sink is None:
                 try_pop(self.sub_sinks, sink_key)
 
-    def write(self, node: Node, source_params: TNode) -> None:
-        for sub_sink in self.sub_sinks.values():
-            sub_sink.write(node, source_params)
+    def write(self, node: Node, source_params: TNode, done_cb: ?action() -> None) -> None:
+        sink_count = len(self.sub_sinks)
+        if sink_count == 0:
+            if done_cb is not None:
+                done_cb()
+        elif done_cb is not None and sink_count > 1:
+            done_collector = CountDoneCallbackCollector(sink_count, done_cb)
+            for sub_sink in self.sub_sinks.values():
+                sub_sink.write(node, source_params, done_collector.on_one_done)
+        else:
+            for sub_sink in self.sub_sinks.values():
+                sub_sink.write(node, source_params, done_cb)
 
     def close(self):
         for sub_sink in self.sub_sinks.values():
@@ -213,20 +601,20 @@ def source_params_try_append_dev_sub(source_params: TNode, dev_sub_key: Keypath)
 
 class Transform(object):
     @property
-    post_fn: action(Node, TNode) -> None
+    post_fn: action(Node, TNode, ?action() -> None) -> None
     @property
     close_fn: action() -> None
 
     def __init__(
             self,
-            post_fn: action(Node, TNode) -> None,
+            post_fn: action(Node, TNode, ?action() -> None) -> None,
             close_fn: action() -> None,
             ):
         self.post_fn = post_fn
         self.close_fn = close_fn
 
-    def post(self, node: Node, source_params: TNode) -> None:
-        self.post_fn(node, source_params)
+    def post(self, node: Node, source_params: TNode, done_cb: ?action() -> None) -> None:
+        self.post_fn(node, source_params, done_cb)
 
     def close(self):
         self.close_fn()

--- a/src/telemetrify/main/main.act
+++ b/src/telemetrify/main/main.act
@@ -33,20 +33,29 @@ from telemetrify.main.common import *
 from telemetrify.main.config import *
 import telemetrify.vmanage.transform
 
-actor DeviceStreamer(env: Env, name: str, shared_schema: schema.SharedSchema, shared_resources: SharedResources, log_handler: ?logging.Handler):
+actor DeviceStreamer(
+        env: Env,
+        name: str,
+        reached_state_cb: action(int) -> None,
+        shared_schema: schema.SharedSchema,
+        shared_resources: SharedResources,
+        log_handler: ?logging.Handler):
+
     var logh = logging.Handler("device-streamer")
     if log_handler is not None:
         logh.set_handler(log_handler)
 
     var log = logging.Logger(logh)
 
-    var sources: dict[Keypath, Source] = {}
+    # var sources_manager: DelegateMiddleManager[Source] = DelegateMiddleManager(on_reached_state, _on_source_reached_state_trampoline)
+    # Workaround compiler ordering issue
+    var source_manager: DelegateMiddleManager[Source] = DelegateMiddleManager(lambda s: None, lambda i, s: None)
     var subscription_sources: dict[Keypath, Keypath] = {}
     var sinks: dict[Keypath, Sink] = {}
 
     log.info("DEVICE CREATED", {"name": name})
 
-    def on_config(
+    def update_config(
             updated_device_config: ?DeviceStreamerConfig,
             subscription_updates: list[(Keypath, ?value)],
             subscription_sink_updates: list[(Keypath, ?value)],
@@ -116,15 +125,15 @@ actor DeviceStreamer(env: Env, name: str, shared_schema: schema.SharedSchema, sh
 
         # Update sources / subscriptions
         for source_key, dev_sub_keys in updated_source_dev_sub_keys.items():
-            source = _get_or_create_source(source_key)
             source_sub_updates: list[(Keypath, ?SubscriptionUpdate)] = []
             for dev_sub_key in dev_sub_keys:
                 source_sub_updates.append((dev_sub_key, try_get(dev_sub_updates, dev_sub_key)))
 
-            source.update_config(try_get(source_config_updates, source_key), source_sub_updates)
+            def _update_fn(s: Source):
+                s.update_config(try_get(source_config_updates, source_key), source_sub_updates)
+            source = _update_source(source_key, _update_fn)
             if not source.has_subscriptions():
-                source.close()
-                del sources[source_key]
+                DelegateMiddleManager_remove_delegate(source_manager, source_key) # https://github.com/actonlang/acton/issues/1448
 
     def _get_subscription_source_key(config: TNode) -> Keypath:
         if config[SUBSCRIPTION_TYPE_KEY_ACTION_POLLER].exists():
@@ -136,22 +145,25 @@ actor DeviceStreamer(env: Env, name: str, shared_schema: schema.SharedSchema, sh
 
         raise Exception("Unknown subscription type: " + str(config))
 
-    def _get_or_create_source(source_key: Keypath) -> Source:
-        _source = try_get(sources, source_key)
+    def _update_source(source_key: Keypath, update_fn: proc(Source) -> None) -> Source:
+        _source: ?Source = DelegateMiddleManager_try_get_delegate(source_manager, source_key)
         if _source is not None:
+            update_fn(_source)
             return _source
+        else:
+            if source_key == SOURCE_KEY_NETCONF:
+                _id, _reached_state_cb = DelegateMiddleManager_reserve_delegate(source_manager, source_key) # https://github.com/actonlang/acton/issues/1448
+                source_act = telemetrify.main.source.netconf.NetconfSource(_reached_state_cb, env.cap, shared_schema, logh)
+                source = Source(source_act.set_target_state, source_act.update_config)
+                DelegateMiddleManager_add_delegate(source_manager, _id, source, update_fn) # https://github.com/actonlang/acton/issues/1448
+                return source
 
-        if source_key == SOURCE_KEY_NETCONF:
-            source_act = telemetrify.main.source.netconf.NetconfSource(env.cap, shared_schema, logh)
-            source = Source(source_key, source_act.update_config, source_act.close)
-            sources[source_key] = source
-            return source
-
-        if source_key == SOURCE_KEY_VMANAGE_HTTP:
-            source_act = telemetrify.main.source.vmanage.VManageSource(env.cap, shared_schema, logh)
-            source = Source(source_key, source_act.update_config, source_act.close)
-            sources[source_key] = source
-            return source
+            if source_key == SOURCE_KEY_VMANAGE_HTTP:
+                _id, _reached_state_cb = DelegateMiddleManager_reserve_delegate(source_manager, source_key) # https://github.com/actonlang/acton/issues/1448
+                source_act = telemetrify.main.source.vmanage.VManageSource(_reached_state_cb, env.cap, shared_schema, logh)
+                source = Source(source_act.set_target_state, source_act.update_config)
+                DelegateMiddleManager_add_delegate(source_manager, _id, source, update_fn) # https://github.com/actonlang/acton/issues/1448
+                return source
 
         raise Exception("Unknown source type: " + str(source_key))
 
@@ -178,7 +190,7 @@ actor DeviceStreamer(env: Env, name: str, shared_schema: schema.SharedSchema, sh
         sink: ?Sink = try_get(sinks, sink_key)
 
         if sink is not None:
-            head_cb: action(Node, TNode) -> None = action lambda n, p: sink.write(n, p, config)
+            head_cb: action(Node, TNode, ?action() -> None) -> None = action lambda n, p, d: sink.write(n, p, config, d)
 
             transforms: list[Transform] = []
             # TODO: Make sure we get elements as 'ordered-by user' from CdbCache/TNode.
@@ -196,7 +208,7 @@ actor DeviceStreamer(env: Env, name: str, shared_schema: schema.SharedSchema, sh
 
         return None
 
-    def _create_transform(config: TNode, next_cb: action(Node, TNode) -> None) -> ?Transform:
+    def _create_transform(config: TNode, next_cb: action(Node, TNode, ?action() -> None) -> None) -> ?Transform:
         # Magic name string for hardcoded transform for now... i.e. demo.
         if eq_optional(config[PTag('tlm', 'name')].try_str(), "vmanage"):
             transform_act = telemetrify.vmanage.transform.Transform(
@@ -214,16 +226,70 @@ actor DeviceStreamer(env: Env, name: str, shared_schema: schema.SharedSchema, sh
             return Transform(transform_act.transform, transform_act.close)
         return None
 
-    def close() -> None:
-        for source in sources.values():
-            source.close()
-        #sources.clear()
-        sources = {}
-        for sink in sinks.values():
-            sink.close()
-        #sinks.clear()
-        sinks = {}
-        log.info("DEVICE CLOSED", {"name": name})
+    def set_target_state(target_state: int):
+        log.debug("DEVICE SET TARGET STATE", {"name": name, "target_state": state_str(target_state)})
+        if not DelegateMiddleManager_set_target_state(source_manager, target_state):
+            log.error("DEVICE UNEXPECTED STATE ignoring", {"name": name, "target_state": state_str(target_state)})
+
+    def on_reached_state(state: int):
+        log.info("DEVICE REACHED STATE " + state_str(state), {"name": name})
+
+        if source_manager.target_state == STATE_CLOSED:
+            for sink in sinks.values():
+                sink.close()
+            #sinks.clear()
+            sinks = {}
+
+        reached_state_cb(state)
+
+    def _on_source_reached_state_trampoline(_id: DelegateId, state: int):
+        # manager.on_delegate_reached_state(_id, state)
+        DelegateMiddleManager_on_delegate_reached_state(source_manager, _id, state) # https://github.com/actonlang/acton/issues/1448
+
+    # Workaround compiler ordering issue
+    source_manager._reached_state_cb = on_reached_state
+    source_manager._delegate_manager._on_delegate_reached_state_trampoline_fn = _on_source_reached_state_trampoline
+
+class DeviceStreamerWrapper(object):
+    @property
+    set_target_state_fn: action(int) -> None
+    @property
+    update_config_fn: action(
+            ?DeviceStreamerConfig,
+            list[(Keypath, ?value)],
+            list[(Keypath, ?value)],
+            list[(Keypath, ?value)],
+            list[(Keypath, ?value)]) -> None
+
+    def __init__(self,
+            set_target_state_fn: action(int) -> None,
+            update_config_fn: action(
+                ?DeviceStreamerConfig,
+                list[(Keypath, ?value)],
+                list[(Keypath, ?value)],
+                list[(Keypath, ?value)],
+                list[(Keypath, ?value)]) -> None):
+
+        self.set_target_state_fn = set_target_state_fn
+        self.update_config_fn = update_config_fn
+
+    def update_config(self,
+            updated_device_config: ?DeviceStreamerConfig,
+            subscription_updates: list[(Keypath, ?value)],
+            subscription_sink_updates: list[(Keypath, ?value)],
+            source_updates: list[(Keypath, ?value)],
+            sink_updates: list[(Keypath, ?value)]):
+
+        self.update_config_fn(
+            updated_device_config,
+            subscription_updates,
+            subscription_sink_updates,
+            source_updates,
+            sink_updates)
+
+extension DeviceStreamerWrapper(Delegate):
+    def set_target_state(self, target_state: int) -> None:
+        self.set_target_state_fn(target_state)
 
 actor SharedResources(env: Env, shared_schema: schema.SharedSchema, log_handler: logging.Handler):
     var l3vpn_svc_tracker: ?telemetrify.ietf.l3vpn_svc.L3vpnSvcTracker = None
@@ -249,7 +315,12 @@ actor SharedResources(env: Env, shared_schema: schema.SharedSchema, log_handler:
         pass # TODO: Could keep refcount and release when not used
 
 actor main(env):
-    var device_streamers: dict[Keypath, DeviceStreamer] = {}
+    # var device_streamers: DelegateManager[DeviceStreamerWrapper] = DelegateManager(
+    #     _on_device_streamer_reached_state_trampoline,
+    #     lambda s: None,
+    #     target_state=STATE_RUNNING)
+    # Workaround compiler ordering issue
+    var device_streamers: DelegateManager[DeviceStreamerWrapper] = DelegateManager(lambda i, s: None, lambda s: None)
     var cache: ?telemetrify.nso.subscriber.CdbCache = None
     var shared_resources: ?SharedResources = None
 
@@ -357,22 +428,6 @@ actor main(env):
                 dict_list_append(updated_subscription_sinks, device_key, (dev_sub_sink_key, state))
                 updated_device_keys.add(device_key)
 
-        for device_key, state in dev_config:
-            if state is not None and isinstance(state, DeviceStreamerConfig):
-                entry = try_get(device_streamers, device_key)
-                if entry is None:
-                    _device_name_key = device_key.try_get_key(0)
-                    if _device_name_key is not None:
-                        device_name = _device_name_key[0]
-                        _shared_resources = shared_resources
-                        if isinstance(device_name, str) and _shared_resources is not None:
-                            device_streamers[device_key] = DeviceStreamer(env, device_name, shared_schema, _shared_resources, logh)
-                updated_device_keys.add(device_key)
-                updated_device_configs[device_key] = state
-            else:
-                _remove_device_streamer(device_key)
-                updated_device_keys.discard(device_key)
-
         for device_source_key, state in source_config:
             device_key = device_source_key.try_slice(0, 1)
             source_key = device_source_key.try_slice(1, 2)
@@ -387,23 +442,43 @@ actor main(env):
                 dict_list_append(updated_device_sinks, device_key, (sink_key, state))
                 updated_device_keys.add(device_key)
 
+        for device_key, state in dev_config:
+            if state is not None and isinstance(state, DeviceStreamerConfig):
+                updated_device_keys.add(device_key)
+                updated_device_configs[device_key] = state
+            else:
+                DelegateManager_remove(device_streamers, device_key) # https://github.com/actonlang/acton/issues/1448
+                updated_device_keys.discard(device_key)
+
         for updated_device_key in updated_device_keys:
-            entry = try_get(device_streamers, updated_device_key)
-            if entry is not None:
-                entry.on_config(
+            def _update_fn(d):
+                d.update_config(
                     try_get(updated_device_configs, updated_device_key),
                     updated_subscriptions.get(updated_device_key, []),
                     updated_subscription_sinks.get(updated_device_key, []),
                     updated_device_sources.get(updated_device_key, []),
                     updated_device_sinks.get(updated_device_key, []))
 
+            entry = DelegateManager_try_get(device_streamers, updated_device_key)
+            if entry is not None:
+                _update_fn(entry)
+            else:
+                _device_name_key = updated_device_key.try_get_key(0)
+                if _device_name_key is not None:
+                    device_name = _device_name_key[0]
+                    _shared_resources = shared_resources
+                    if isinstance(device_name, str) and _shared_resources is not None:
+                        _id, reached_state_cb = DelegateManager_reserve(device_streamers, updated_device_key) # https://github.com/actonlang/acton/issues/1448
+                        ds_act = DeviceStreamer(env, device_name, reached_state_cb, shared_schema, _shared_resources, logh)
+                        device_streamer = DeviceStreamerWrapper(ds_act.set_target_state, ds_act.update_config)
+                        DelegateManager_add(device_streamers, _id, device_streamer, _update_fn) # https://github.com/actonlang/acton/issues/1448
+
         # Logging
         _on_logging_level(refiner_updates[LoggingLevelRefiner.id()])
 
-    def _remove_device_streamer(device_key):
-        entry = try_pop(device_streamers, device_key)
-        if entry is not None:
-            entry.close()
+    def _on_device_streamer_reached_state_trampoline(_id: DelegateId, state: int):
+        # device_streamers.on_delegate_reached_state(_id, state)
+        DelegateManager_on_delegate_reached_state(device_streamers, _id, state) # https://github.com/actonlang/acton/issues/1448
 
     def _on_logging_level(updates: list[(Keypath, ?value)]):
         level: ?int = None
@@ -446,6 +521,10 @@ actor main(env):
     def _on_config_cache_error(e):
         log.error("CdbCache failed:" + optional_str(e.error_message, ""), None)
         await async env.exit(1)
+
+    # Workaround compiler ordering issue
+    device_streamers._on_delegate_reached_state_trampoline_fn = _on_device_streamer_reached_state_trampoline
+    DelegateManager_set_target_state(device_streamers, STATE_RUNNING)
 
     log.info("Starting up...", None)
     maapi_connection = telemetrify.nsoapi.maapi.MaapiConnection(env, 4569, _on_maapi_connect, _on_maapi_connect_error, logh, None)

--- a/src/telemetrify/main/sink/m3db.act
+++ b/src/telemetrify/main/sink/m3db.act
@@ -1,3 +1,16 @@
+# Copyright (C) Deutsche Telekom AG
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
 import logging
 import net
 import time
@@ -9,6 +22,7 @@ import tsdb.m3
 from telemetrify.common.mod import *
 from telemetrify.common.utils import *
 from telemetrify.nsoapi.schema import SchemaPath
+from telemetrify.main.common import *
 
 actor M3dbSink(auth: WorldCap, config: TNode, shared_schema: schema.SharedSchema, log_handler: logging.Handler):
     var logh = logging.Handler("m3db-sink")
@@ -24,60 +38,43 @@ actor M3dbSink(auth: WorldCap, config: TNode, shared_schema: schema.SharedSchema
     var client: ?tsdb.m3.Client = None
     var writer: ?telemetrify.tsdb.writer.TSDBWriter = None
 
+    var tasks: Wardrobe[(Node, TNode, TNode, ?action() -> None)] = Wardrobe() # (node, source_params, sink_config, done_cb)
+    var state = STATE_STOPPED
+
     log.info("SINK m3db CREATED", None)
 
-    def write(node: Node, source_params: TNode, sink_config: TNode) -> None:
-        w = writer
-        if w is not None:
-            _schema_path: ?value = source_params[PTag(None, 'schema_path')].value()
-            schema_path: ?SchemaPath = _schema_path if _schema_path is not None and isinstance(_schema_path, SchemaPath) else None
-            _timestamp: ?value = source_params[PTag(None, 'timestamp')].value()
-            timestamp: time.Instant = _timestamp if _timestamp is not None and isinstance(_timestamp, time.Instant) else time.time()
-            base_tags: list[(str, str)] = []
-            for tag_entry in sink_config[PTag(None, 'base_tags')].iter():
-                _tag = tag_entry[PTag(None, 'name')].try_str()
-                _value = tag_entry[PTag(None, 'value')].try_str()
-                if _tag is not None and _value is not None:
-                    base_tags.append((_tag, _value))
+    def write(node: Node, source_params: TNode, sink_config: TNode, done_cb: ?action() -> None) -> None:
+        # We don't need to messages when outputing to a log-style sink that is not ready.
+        if state == STATE_RUNNING:
+            w = writer
+            if w is not None:
+                task_id = tasks.put((node, source_params, sink_config))
+                _write(w, task_id, node, source_params, sink_config)
+                return
+        if done_cb is not None:
+            done_cb()
 
-            m3db_timestamp = timestamp.second # TODO: Subsecond precision
-            # TODO:
-            # Why: Cannot unify ?T_619 and telemetrify.common.mod.SchemaPath
-            # when argment is ?SchemaPath ?
-            #w.write(node, schema_path, [], base_tags, m3db_timestamp, _on_write_done)
-            w.write(node, schema_path if schema_path is not None else SchemaPath([], []), base_tags, m3db_timestamp, _on_write_done)
-        else:
-            # TODO:
-            # Buffer until (re-)connected or signal connection upwards for possible source subscription sync?
-            # Not really relevant for periodic time-series ...
-            pass
-            # # <TEST>
-            # _schema_path: ?value = source_params[PTag(None, 'schema_path')].value()
-            # schema_path: ?SchemaPath = _schema_path if _schema_path is not None and isinstance(_schema_path, SchemaPath) else None
-            # _timestamp: ?value = source_params[PTag(None, 'timestamp')].value()
-            # timestamp: time.Instant = _timestamp if _timestamp is not None and isinstance(_timestamp, time.Instant) else time.time()
-            # base_tags: list[(str, str)] = []
-            # for tag_entry in sink_config[PTag(None, 'base_tags')].iter():
-            #     _tag = tag_entry[PTag(None, 'name')].try_str()
-            #     _value = tag_entry[PTag(None, 'value')].try_str()
-            #     if _tag is not None and _value is not None:
-            #         base_tags.append((_tag, _value))
-            # m3db_timestamp = timestamp.second # TODO: Subsecond precision
-            # print("SINK m3db WRITE Attempted", node, optional_str(schema_path, "None"), base_tags, m3db_timestamp)
-            # # </TEST>
+    def _write(_writer: telemetrify.tsdb.writer.TSDBWriter, task_id: int, node: Node, source_params: TNode, sink_config: TNode) -> None:
+        _schema_path: ?value = source_params[SOURCE_PARAM_SCHEMA_PATH].value()
+        schema_path: ?SchemaPath = _schema_path if _schema_path is not None and isinstance(_schema_path, SchemaPath) else None
+        _timestamp: ?value = source_params[SOURCE_PARAM_TIMESTAMP].value()
+        timestamp: time.Instant = _timestamp if _timestamp is not None and isinstance(_timestamp, time.Instant) else time.time()
+        base_tags: list[(str, str)] = []
+        for tag_entry in sink_config[SOURCE_PARAM_BASE_TAGS].iter():
+            _tag = tag_entry[PTag(None, 'name')].try_str()
+            _value = tag_entry[PTag(None, 'value')].try_str()
+            if _tag is not None and _value is not None:
+                base_tags.append((_tag, _value))
+
+        m3db_timestamp = timestamp.second # TODO: Subsecond precision
+        # TODO:
+        # Why: Cannot unify ?T_619 and telemetrify.common.mod.SchemaPath
+        # when argment is ?SchemaPath ?
+        #w.write(node, schema_path, [], base_tags, m3db_timestamp, lambda c, e: _on_write_done(c, e, task_id))
+        _writer.write(node, schema_path if schema_path is not None else SchemaPath([], []), base_tags, m3db_timestamp, lambda c, e: _on_write_done(c, e, task_id))
 
     def close():
-        # TODO: Flush writer?
-        # _writer = writer
-        # if _writer is not None:
-        #     _writer.flush()
-        _client = client
-        if _client is not None:
-            # TODO:
-            # _client.close()
-            pass
-
-        log.info("SINK m3db CLOSED", None)
+        _close()
 
     def _on_tsdb_connect(c: tsdb.m3.Client):
         client = c
@@ -87,19 +84,45 @@ actor M3dbSink(auth: WorldCap, config: TNode, shared_schema: schema.SharedSchema
     def _on_tsdb_init(c: tsdb.m3.Client, success: bool):
         writer = telemetrify.tsdb.writer.TSDBWriter(c, shared_schema)
         log.info("SINK m3db INITIALIZED", None)
+        state = STATE_RUNNING
 
     def _on_tsdb_error(c: tsdb.m3.Client, e):
         log.error("SINK m3db CLIENT ERROR:", {"error": str(e)})
         # TODO: Reconnect ourselves or pass along upwards?
+        _close()
 
-    def _on_write_done(c, e):
+    def _on_write_done(c, e, task_id: int):
         if e is not None:
             log.error("SINK m3db WRITE ERROR:", {"error": str(e)})
         else:
             log.info("SINK m3db WRITE DONE", None)
+        _complete_task(task_id)
 
-    #log_handler.add_sink(logging.StdoutSink())
+    def _complete_task(task_id: int):
+        try:
+            _node, _source_params, _sink_config, done_cb = tasks.pop(task_id)
+        except KeyError:
+            pass
+        else:
+            if done_cb is not None:
+                done_cb()
 
-    #log = logging.Logger(log_handler)
+    def _complete_tasks():
+        for _task_id, (_node, _source_params, _sink_config, done_cb) in tasks.pop_all():
+            if done_cb is not None:
+                done_cb()
+
+    def _close():
+        _complete_tasks()
+        if state != STATE_CLOSED:
+            state = STATE_CLOSED
+            _writer = writer
+            if _writer is not None:
+                _writer = None
+            log.info("SINK m3db CLOSED", None)
+
+    # TODO: When we have destructors support in acton
+    def __del__():
+        _close()
 
     tsdb.m3.Client(net.TCPConnectCap(net.TCPCap(net.NetCap(auth))), address, port, _on_tsdb_connect, _on_tsdb_error, logh)

--- a/src/telemetrify/main/sink/nso.act
+++ b/src/telemetrify/main/sink/nso.act
@@ -1,3 +1,16 @@
+# Copyright (C) Deutsche Telekom AG
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
 import logging
 import time
 import xml
@@ -10,7 +23,7 @@ from telemetrify.common.mod import *
 from telemetrify.common.utils import *
 from telemetrify.nso.writer import *
 from telemetrify.nsoapi.maapi import *
-from telemetrify.main.config import *
+from telemetrify.main.common import *
 
 actor NsoCdbSink(env: Env, config: TNode, shared_schema: schema.SharedSchema, log_handler: logging.Handler):
     var logh = logging.Handler("nso-cdb-sink")
@@ -22,20 +35,33 @@ actor NsoCdbSink(env: Env, config: TNode, shared_schema: schema.SharedSchema, lo
     var maapi_connection: ?telemetrify.nsoapi.maapi.MaapiConnection = None
     var writer: ?telemetrify.nso.writer.MaapiWriter = None
 
-    var tasks: Wardrobe[(Node, TNode, TNode)] = Wardrobe() # (node, source_params, sink_config)
+    var tasks: Wardrobe[(Node, TNode, TNode, ?action() -> None)] = Wardrobe() # (node, source_params, sink_config, done_cb)
+    var state = STATE_STARTING
 
     log.info("SINK nso-cdb CREATED", None)
 
-    def write(node: Node, source_params: TNode, sink_config: TNode) -> None:
+    def write(node: Node, source_params: TNode, sink_config: TNode, done_cb: ?action() -> None) -> None:
+        if state != STATE_CLOSED:
+            task_id = tasks.put((node, source_params, sink_config, done_cb))
+            # We want to buffer messages when outputing to a stateful sink that is not yet initialized.
+            # Depend on timely connect/init success/failure response from local maapi.
+            if state == STATE_RUNNING:
+                _run_task(task_id)
+        else:
+            if done_cb is not None:
+                done_cb() # TODO: Pass along ClosedException?
+
+    def _run_task(task_id: int):
         m = maapi_connection
-        w = writer
-        if m is not None and w is not None:
-            task_id = tasks.put((node, source_params, sink_config))
+        if m is not None:
             m.start_trans(DB_OPERATIONAL, MODE_READ_WRITE, UserIdentity(None, None, None, None), lambda c, t: _on_start_trans(c, t, task_id))
         else:
-            # TODO:
-            # Buffer until (re-)connected or signal connection upwards for possible source subscription sync?
-            pass
+            _complete_task(task_id)
+
+    def _on_running():
+        state = STATE_RUNNING
+        for task_id in tasks.get_tickets():
+            _run_task(task_id)
 
     def _on_start_trans(_m, txn_handle, task_id):
         if isinstance(txn_handle, int):
@@ -43,13 +69,15 @@ actor NsoCdbSink(env: Env, config: TNode, shared_schema: schema.SharedSchema, lo
             w = writer
             if w is not None:
                 try:
-                    node, source_params, sink_config = tasks.borrow(task_id)
-                except Exception:
+                    node, source_params, sink_config, _done_cb = tasks.borrow(task_id)
+                except KeyError:
                     pass
                 else:
                     w.write(node, txn_handle, False, lambda e: _on_write(e, txn_handle, task_id))
+                    return
         else:
             log.error("SINK nso-cdb MAAPI start transaction failed:", {"txn_handle": txn_handle})
+        _complete_task(task_id)
 
     def _on_write(e: ?Exception, txn_handle: int, task_id: int):
         if e is not None:
@@ -57,6 +85,8 @@ actor NsoCdbSink(env: Env, config: TNode, shared_schema: schema.SharedSchema, lo
         m = maapi_connection
         if m is not None:
             m.apply_trans(txn_handle, False, 0, lambda _c, e: _on_apply_trans(e, txn_handle, task_id))
+            return
+        _complete_task(task_id)
 
     def _on_apply_trans(e: ?Exception, txn_handle: int, task_id: int):
         if e is not None:
@@ -64,43 +94,71 @@ actor NsoCdbSink(env: Env, config: TNode, shared_schema: schema.SharedSchema, lo
         m = maapi_connection
         if m is not None:
             m.finish_trans(txn_handle, lambda _c, e: _on_finish_trans(e, txn_handle, task_id))
+            return
+        _complete_task(task_id)
 
     def _on_finish_trans(e: ?Exception, txn_handle: int, task_id: int):
         if e is not None:
             log.error("SINK nso-cdb MAAPI finish transaction failed:", {"txn_handle": txn_handle, "exception": e})
         else:
             log.debug("SINK nso-cdb WRITE DONE", None)
-        try:
-            tasks.discard(task_id)
-        except Exception:
-            pass
+        _complete_task(task_id)
 
     def _on_maapi_connect(_m: MaapiConnection):
         log.info("SINK nso-cdb MAAPI connect complete", None)
         m = maapi_connection
         if m is not None:
             m.start_user_session(UserSessionDescription("admin", "127.0.0.1", "system", [], None, False, UserIdentity(None, None, None, None)), _on_user_session)
+            return
+        _close()
 
     def _on_user_session(c, e):
         m = maapi_connection
         if m is not None:
             writer = telemetrify.nso.writer.MaapiWriter(m, shared_schema, logh)
+            _on_running()
+            return
+        _close()
+        # TODO: retry?
 
     def _on_maapi_connect_error(e):
-        log.error("SINK nso-cdb MAAPI connect failed:", {"error": e})
-        # TODO: retry? We should probably panic/exit/crash if we don't have a local NSO
+        log.error("SINK nso-cdb MAAPI connect failed CLOSING", {"error": e})
+        _close()
+        # TODO: retry?
+
+    def _complete_task(task_id: int):
+        try:
+            _node, _source_params, _sink_config, done_cb = tasks.pop(task_id)
+        except KeyError:
+            pass
+        else:
+            if done_cb is not None:
+                done_cb()
+
+    def _complete_tasks():
+        for _task_id, (_node, _source_params, _sink_config, done_cb) in tasks.pop_all():
+            if done_cb is not None:
+                done_cb()
 
     def close():
-        _writer = writer
-        if _writer is not None:
-            # TODO
-            # _writer.close()
-            _writer = None
-        _maapi_connection = maapi_connection
-        if _maapi_connection is not None:
-            _maapi_connection.close()
-            maapi_connection = None
-        tasks.clear()
-        log.info("SINK nso-cdb CLOSED", None)
+        _close()
+
+    def _close():
+        _complete_tasks()
+        if state != STATE_CLOSED:
+            state = STATE_CLOSED
+            _writer = writer
+            if _writer is not None:
+                _writer = None
+            _maapi_connection = maapi_connection
+            if _maapi_connection is not None:
+                _maapi_connection.close()
+                maapi_connection = None
+            tasks.clear()
+            log.info("SINK nso-cdb CLOSED", None)
+
+    # TODO: When we have destructors support in acton
+    def __del__():
+        _close()
 
     maapi_connection = telemetrify.nsoapi.maapi.MaapiConnection(env, 4569, _on_maapi_connect, _on_maapi_connect_error, logh, None)

--- a/src/telemetrify/main/source/netconf.act
+++ b/src/telemetrify/main/source/netconf.act
@@ -1,3 +1,16 @@
+# Copyright (C) Deutsche Telekom AG
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
 import logging
 import net
 import time
@@ -12,8 +25,12 @@ from telemetrify.nsoapi.schema import QName, SchemaPath
 from telemetrify.main.common import *
 from telemetrify.main.config import *
 
-#actor NetconfSource(auth: WorldCap, on_ready: action(), on_error: action(str) -> None, on_closed() -> None):
-actor NetconfSource(auth: WorldCap, shared_schema: schema.SharedSchema, log_handler: logging.Handler):
+actor NetconfSource(
+        reached_state_cb: action(int) -> None,
+        auth: WorldCap,
+        shared_schema: schema.SharedSchema,
+        log_handler: logging.Handler):
+
     var logh = logging.Handler("netconf-source")
     if log_handler is not None:
         logh.set_handler(log_handler)
@@ -23,26 +40,11 @@ actor NetconfSource(auth: WorldCap, shared_schema: schema.SharedSchema, log_hand
     var config: TNode = tnode_empty()
     var client: ?netconf.Client = None
     var client_seqno: int = 0
-    var subscribers: dict[Keypath, Subscriber] = {}
+    # var manager: DelegateMiddleManager[Subscriber] = DelegateMiddleManager(on_reached_state, _on_subscriber_reached_state_trampoline, _connect_client, _close_client)
+    # Workaround compiler ordering issue
+    var manager: DelegateMiddleManager[Subscriber] = DelegateMiddleManager(lambda s: None, lambda i, s: None, lambda: None, lambda: None)
 
     log.info("SOURCE netconf CREATED", None)
-
-    def _on_client_connect(seqno: int):
-        if seqno != client_seqno:
-            return
-        _start_subscribers()
-
-    def _on_client_error(error_msg: str, seqno: int):
-        if seqno != client_seqno:
-            return
-        _close_client()
-        # TODO: Configurable retry timer/backoff?
-        after 1: _connect_client()
-
-    def _on_client_notif(node: xml.Node, seqno: int):
-        # if seqno != client_seqno:
-        #     return
-        pass
 
     def update_config(source_update: ?TNode, subscription_updates: list[(Keypath, ?SubscriptionUpdate)]):
         log.debug("SOURCE netconf CONFIG update", {"source_update": optional_str(source_update, "None")})
@@ -51,52 +53,94 @@ actor NetconfSource(auth: WorldCap, shared_schema: schema.SharedSchema, log_hand
         restart = False
 
         if source_update is not None:
-            if _close_client():
-                restart = True
-
             config = source_update
-
-            _connect_client()
+            DelegateMiddleManager_try_restart_inner(manager)
 
         for dev_sub_key, sub_update in subscription_updates:
             if sub_update is not None:
                 log.trace("SOURCE netconf SUBSCRIPTION update", {"sub_update": sub_update})
-                sub = try_get(subscribers, dev_sub_key)
+                # sub = manager.try_get_delegate(dev_sub_key)
+                sub = DelegateMiddleManager_try_get_delegate(manager, dev_sub_key) # https://github.com/actonlang/acton/issues/1448
+
                 if sub is not None:
                     log.trace("SOURCE netconf SUBSCRIPTION update exists", {"sub_update": sub_update})
                     sub.update_config(sub_update)
                 else:
                     log.trace("SOURCE netconf SUBSCRIPTION update is new", {"sub_update": sub_update})
                     new_sub = _create_subscriber(dev_sub_key, sub_update)
-                    new_sub.update_config(sub_update)
-                    log.trace("SOURCE netconf SUBSCRIPTION update 'restart'", {"restart": restart})
-                    log.trace("SOURCE netconf SUBSCRIPTION update 'client'", {"client": optional_str(client, "None")})
-                    if not restart and client is not None:
-                        log.debug("SOURCE netconf SUBSCRIPTION update to start", {"sub_update": sub_update})
-                        new_sub.start()
-                    subscribers[dev_sub_key] = new_sub
             else:
-                sub = try_pop(subscribers, dev_sub_key)
-                if sub is not None:
-                    sub.close()
-
-        if restart:
-            _start_subscribers()
+                # manager.remove_delegate(dev_sub_key)
+                DelegateMiddleManager_remove_delegate(manager, dev_sub_key) # https://github.com/actonlang/acton/issues/1448
 
     def _create_subscriber(dev_sub_key: Keypath, sub_update: SubscriptionUpdate) -> Subscriber:
         sub_config = sub_update.config
         if sub_config is not None:
             _config = sub_config.config
             if _config[SUBSCRIPTION_TYPE_KEY_ACTION_POLLER].exists():
-                sub_act = NetconfRpcPollSubscription(self, dev_sub_key, shared_schema, logh)
-                return Subscriber(sub_act.update_config, sub_act.start, sub_act.stop, sub_act.close)
+                _id, _reached_state_cb = DelegateMiddleManager_reserve_delegate(manager, dev_sub_key) # https://github.com/actonlang/acton/issues/1448
+                sub_act = NetconfRpcPollSubscription(self, dev_sub_key, _reached_state_cb, shared_schema, logh)
+                sub = Subscriber(sub_act.set_target_state, sub_act.update_config)
+                DelegateMiddleManager_add_delegate(manager, _id, sub, lambda s: s.update_config(sub_update)) # https://github.com/actonlang/acton/issues/1448
+                return sub
             elif _config[SUBSCRIPTION_TYPE_KEY_GET_POLLER].exists():
-                sub_act = NetconfGetPollSubscription(self, dev_sub_key, shared_schema, logh)
-                return Subscriber(sub_act.update_config, sub_act.start, sub_act.stop, sub_act.close)
+                _id, _reached_state_cb = DelegateMiddleManager_reserve_delegate(manager, dev_sub_key) # https://github.com/actonlang/acton/issues/1448
+                sub_act = NetconfGetPollSubscription(self, dev_sub_key, _reached_state_cb, shared_schema, logh)
+                sub = Subscriber(sub_act.set_target_state, sub_act.update_config)
+                DelegateMiddleManager_add_delegate(manager, _id, sub, lambda s: s.update_config(sub_update)) # https://github.com/actonlang/acton/issues/1448
+                return sub
 
         raise Exception("Broken invariant: Attempted to create subscriber from invalid config: " + optional_str(sub_config, "None"))
 
+    def rpc(content: xml.Node, add_rpc_attrs: list[(str, str)], callback: action(?xml.Node) -> None) -> None:
+        _client = client
+        if _client is not None:
+            # actonc: Acton/LambdaLifter.hs:(337,50)-(340,84): Non-exhaustive patterns in function attr
+            # _client.rpc(content, add_rpc_attrs, lambda _c, n: callback(n))
+            def __callback(_c, n):
+                callback(n)
+            _client.rpc(content, add_rpc_attrs, __callback)
+        else:
+            callback(None)
+
+    def rpc_action(content: xml.Node, add_rpc_attrs: list[(str, str)], callback: action(?xml.Node) -> None) -> None:
+        _client = client
+        if _client is not None:
+            # actonc: Acton/LambdaLifter.hs:(337,50)-(340,84): Non-exhaustive patterns in function attr
+            # _client.rpc_action(content, add_rpc_attrs, lambda _c, n: callback(n))
+            def __callback(_c, n):
+                callback(n)
+            _client.rpc_action(content, add_rpc_attrs, __callback)
+        else:
+            callback(None)
+
+    def _on_client_connect(c, seqno: int):
+        if seqno != client_seqno:
+            c.close()
+            return
+        log.debug("SOURCE netconf CONNECTED", None)
+        DelegateMiddleManager_on_inner_started(manager)
+
+    def _on_client_defunct(error_msg: str, seqno: int):
+        if seqno != client_seqno:
+            return
+        _close_client()
+
+        def _retry_client():
+            if manager.target_state == STATE_RUNNING:
+                _connect_client()
+
+        # TODO: Configurable retry timer/backoff?
+        after 1: _retry_client()
+
+    def _on_client_notif(node: xml.Node, seqno: int):
+        # if seqno != client_seqno:
+        #     return
+        pass
+
     def _connect_client():
+        if client is not None:
+            return
+
         address = config[PTag('tlm', 'address')].try_str()
         port = config[PTag('tlm', 'port')].try_int()
         username = config[PTag('tlm', 'username')].try_str()
@@ -109,78 +153,66 @@ actor NetconfSource(auth: WorldCap, shared_schema: schema.SharedSchema, log_hand
 
             client_seqno += 1
 
-            def __on_client_connect(_c):
-                _on_client_connect(client_seqno)
-            def __on_client_error(_c, e):
-                _on_client_error(e, client_seqno)
+            def __on_client_connect(c):
+                _on_client_connect(c, client_seqno)
+            def __on_client_defunct(_c, e):
+                _on_client_defunct(e, client_seqno)
             def __on_client_notif(_c, n):
                 _on_client_notif(n, client_seqno)
 
             new_client = netconf.Client(auth, address, port, username, password, key,
                 # lambda _c: _on_client_connect(client_seqno),
                 __on_client_connect,
-                # lambda _c, e: _on_client_error(e, client_seqno),
-                __on_client_error,
+                # lambda _c, e: _on_client_defunct(e, client_seqno),
+                __on_client_defunct,
                 # lambda _c, n: _on_client_notif(n, client_seqno))
                 __on_client_notif,
                 logh)
 
             client = new_client
 
-        # # <TEST>
-        # after 0: _start_subscribers()
-        # # </TEST>
+            # # <TEST>
+            # def _pretend_connect():
+            #     log.debug("SOURCE netconf CONNECTED (pretending)", None)
+            #     DelegateMiddleManager_on_inner_started(manager)
+            # after 0: _pretend_connect()
+            # # </TEST>
 
-    def _close_client() -> bool:
+    def _close_client():
+        log.debug("SOURCE netconf DISCONNECT", None)
         _client = client
         if _client is not None:
-            _stop_subscribers()
-            # TODO: Gather stop replies from subscribers before closing netconf client?
+            client_seqno += 1
             _client.close()
             client = None
-            return True
-        return False
+        DelegateMiddleManager_on_inner_stopped(manager)
 
-    def _start_subscribers():
-        for subscriber in subscribers.values():
-            subscriber.start()
+    def set_target_state(target_state: int):
+        log.debug("SOURCE netconf SET TARGET STATE", {"target_state": state_str(target_state)})
+        if not DelegateMiddleManager_set_target_state(manager, target_state):
+            log.error("SOURCE netconf UNEXPECTED STATE ignoring", {"target_state": state_str(target_state)})
 
-    def _stop_subscribers():
-        for subscriber in subscribers.values():
-            subscriber.stop()
+    def on_reached_state(state: int):
+        log.info("SOURCE netconf REACHED STATE " + state_str(state), None)
+        reached_state_cb(state)
 
-    def rpc(content: xml.Node, add_rpc_attrs: list[(str, str)], callback: action(?xml.Node) -> None) -> None:
-        if client is not None:
-            # actonc: Acton/LambdaLifter.hs:(337,50)-(340,84): Non-exhaustive patterns in function attr
-            # client.rpc(content, add_rpc_attrs, lambda _c, n: callback(n))
-            def __callback(_c, n):
-                callback(n)
-            client.rpc(content, add_rpc_attrs, __callback)
-        else:
-            callback(None)
+    def _on_subscriber_reached_state_trampoline(_id: DelegateId, state: int):
+        # manager.on_delegate_reached_state(_id, state)
+        DelegateMiddleManager_on_delegate_reached_state(manager, _id, state) # https://github.com/actonlang/acton/issues/1448
 
-    def rpc_action(content: xml.Node, add_rpc_attrs: list[(str, str)], callback: action(?xml.Node) -> None) -> None:
-        if client is not None:
-            # actonc: Acton/LambdaLifter.hs:(337,50)-(340,84): Non-exhaustive patterns in function attr
-            # client.rpc_action(content, add_rpc_attrs, lambda _c, n: callback(n))
-            def __callback(_c, n):
-                callback(n)
-            client.rpc_action(content, add_rpc_attrs, __callback)
-        else:
-            callback(None)
+    # Workaround compiler ordering issue
+    manager._start_fn = _connect_client
+    manager._stop_fn = _close_client
+    manager._reached_state_cb = on_reached_state
+    manager._delegate_manager._on_delegate_reached_state_trampoline_fn = _on_subscriber_reached_state_trampoline
 
-    def close():
-        _client = client
-        if _client is not None:
-            _client.close()
-            client = None
-        for subscriber in subscribers.values():
-            subscriber.close()
-        #subscribers.clear()
-        subscribers = {}
-        log.info("SOURCE netconf CLOSED", None)
+actor NetconfRpcPollSubscription(
+        source: NetconfSource,
+        dev_sub_key: Keypath,
+        reached_state_cb: action(int) -> None,
+        shared_schema: schema.SharedSchema,
+        log_handler: ?logging.Handler):
 
-actor NetconfRpcPollSubscription(source: NetconfSource, dev_sub_key: Keypath, shared_schema: schema.SharedSchema, log_handler: ?logging.Handler):
     var logh = logging.Handler("netconf-rpc-poll-subscription")
     if log_handler is not None:
         logh.set_handler(log_handler)
@@ -196,7 +228,9 @@ actor NetconfRpcPollSubscription(source: NetconfSource, dev_sub_key: Keypath, sh
     var schema_path: ?SchemaPath = None
     var period: time.Duration = time.Duration(60, 0, time.MonotonicClock(0, 0, 0))
 
-    var is_running: bool = False
+    # var worker_state = DelegateWorker(on_reached_state, _on_start, _on_stop)
+    # Workaround compiler ordering issue
+    var worker_state = DelegateWorker(lambda s: None, lambda: None, lambda: None)
 
     log.info("SUBSCRIBER netconf-rpc-poll CREATED", None)
 
@@ -238,13 +272,13 @@ actor NetconfRpcPollSubscription(source: NetconfSource, dev_sub_key: Keypath, sh
 
         # TODO: Process node
         if node is not None:
-            xnode = netconf.netconf_to_xnode(node, [], 0)
+            xnode = netconf.netconf_to_xnode(node, [], OP_MERGE)
             log.debug("SUBSCRIBER netconf-rpc-poll POLL:", {"xnode": xnode})
             source_params = tnode_root()
             source_params_try_append_dev_sub(source_params, dev_sub_key)
-            source_params.leaf(None, PTag(None, 'timestamp'), request_ts)
+            source_params.leaf(None, SOURCE_PARAM_TIMESTAMP, request_ts)
             if schema_path is not None:
-                source_params.leaf(None, PTag(None, 'schema_path'), schema_path)
+                source_params.leaf(None, SOURCE_PARAM_SCHEMA_PATH, schema_path)
             sinks.write(xnode, source_params)
         else:
             log.error("SUBSCRIBER netconf-rpc-poll POLL interrupted", None)
@@ -267,14 +301,13 @@ actor NetconfRpcPollSubscription(source: NetconfSource, dev_sub_key: Keypath, sh
         log.debug("delay (s)", {"delay": delay.to_float()})
         after delay.to_float(): _do_rpc_request(seqno, next_ts)
 
-    #def update_sinks(sink_updates: list[(Keypath, ?SubscriptionSink)]):
     def update_config(update: SubscriptionUpdate):
-        sinks.update(update.sinks)
+        sinks.update_added(update.sinks)
 
         __config = update.config
         if __config is not None:
             _config: SubscriptionSourceConfig = __config
-            _stop_poller()
+            DelegateWorker_try_restart_inner(worker_state)
             log.debug("SUBSCRIBER netconf-rpc-poll CONFIG", {"config": _config})
 
             poll = _config.config[SUBSCRIPTION_TYPE_KEY_ACTION_POLLER]
@@ -291,10 +324,10 @@ actor NetconfRpcPollSubscription(source: NetconfSource, dev_sub_key: Keypath, sh
             if period_ms is not None and rpc_xml is not None:
                 period = time.Duration(period_ms // 10**3, (period_ms % 10**3) * 10**15, time.MonotonicClock(0, 0, 0))
                 #print("period: " + str(period.to_float()) + "s")
-                if is_running:
-                    _try_start_poller()
             else:
                 pass # TODO: Indicate config error
+
+        sinks.update_removed(update.sinks)
 
     def _update_rpc_params(rpc_path: Keypath, schema_settings: SchemaSettings):
         _rpc_xml: ?xml.Node = None
@@ -348,31 +381,55 @@ actor NetconfRpcPollSubscription(source: NetconfSource, dev_sub_key: Keypath, sh
         is_action = _is_action
         schema_path = _schema_path
 
-    def _try_start_poller():
+    def _start():
+        log.debug("SUBSCRIBER netconf-rpc-poll START", None)
+
         if rpc_xml is not None:
             curr_ts = time.monotonic()
             after 0: _do_rpc_request(poller_seqno, curr_ts)
+        DelegateWorker_on_inner_started(worker_state)
 
-    def _stop_poller():
+    def _stop():
+        log.debug("SUBSCRIBER netconf-rpc-poll STOP", None)
+
+        # stop poller
         poller_seqno += 1
 
-    def start():
-        if not is_running:
-            log.info("SUBSCRIBER netconf-rpc-poll STARTED", None)
-            is_running = True
-            _try_start_poller()
+        # write RESET
+        cleanup_payload = XTree(OP_NOCREATE, ITag.root(), None, []) # TODO
+        source_params = tnode_root()
+        source_params_try_append_dev_sub(source_params, dev_sub_key)
+        source_params.leaf(None, SOURCE_PARAM_TIMESTAMP, time.time())
+        if schema_path is not None:
+            source_params.leaf(None, SOURCE_PARAM_SCHEMA_PATH, schema_path)
+        source_params.leaf(None, SOURCE_PARAM_RESET, None)
+        sinks.write(cleanup_payload, source_params, _on_sink_reset)
 
-    def stop():
-        if is_running:
-            log.info("SUBSCRIBER netconf-rpc-poll STOPPED", None)
-            is_running = False
-            _stop_poller()
+    def _on_sink_reset():
+        log.trace("SUBSCRIBER netconf-rpc-poll SINK RESET DONE", None)
+        DelegateWorker_on_inner_stopped(worker_state)
 
-    def close():
-        stop()
-        log.info("SUBSCRIBER netconf-rpc-poll CLOSED", None)
+    def set_target_state(target_state: int):
+        log.debug("SUBSCRIBER netconf-rpc-poll SET TARGET STATE", {"target_state": state_str(target_state)})
+        if not DelegateWorker_set_target_state(worker_state, target_state):
+            log.error("SUBSCRIBER netconf-rpc-poll UNEXPECTED STATE ignoring", {"target_state": state_str(target_state)})
 
-actor NetconfGetPollSubscription(source: NetconfSource, dev_sub_key: Keypath, shared_schema: schema.SharedSchema, log_handler: ?logging.Handler):
+    def on_reached_state(state: int):
+        log.info("SUBSCRIBER netconf-rpc-poll REACHED STATE " + state_str(state), None)
+        reached_state_cb(state)
+
+    # Workaround compiler ordering issue
+    worker_state._start_fn = _start
+    worker_state._stop_fn = _stop
+    worker_state._reached_state_cb = on_reached_state
+
+actor NetconfGetPollSubscription(
+        source: NetconfSource,
+        dev_sub_key: Keypath,
+        reached_state_cb: action(int) -> None,
+        shared_schema: schema.SharedSchema,
+        log_handler: ?logging.Handler):
+
     var logh = logging.Handler("netconf-get-poll")
     if log_handler is not None:
         logh.set_handler(log_handler)
@@ -387,14 +444,16 @@ actor NetconfGetPollSubscription(source: NetconfSource, dev_sub_key: Keypath, sh
     var schema_path: ?SchemaPath = None
     var period: time.Duration = time.Duration(60, 0, time.MonotonicClock(0, 0, 0))
 
-    var is_running: bool = False
+    # var worker_state = DelegateWorker(on_reached_state, _on_start, _on_stop)
+    # Workaround compiler ordering issue
+    var worker_state = DelegateWorker(lambda s: None, lambda: None, lambda: None)
 
     log.info("SUBSCRIBER netconf-get-poll CREATED", None)
 
     def _do_get_request(seqno: int, poll_ts: time.Instant):
-        log.debug("SUBSCRIBER netconf-get-poll GET_REQUEST", None)
         if seqno != poller_seqno:
             return
+        log.debug("SUBSCRIBER netconf-get-poll GET_REQUEST", None)
 
         log.trace("SUBSCRIBER netconf-get-poll GET_XML", {"get_xml": optional_str(get_xml, "None")})
         if get_xml is not None:
@@ -514,13 +573,13 @@ actor NetconfGetPollSubscription(source: NetconfSource, dev_sub_key: Keypath, sh
                  node = node.children[0]
                  if node.tag == "data" and len(node.children) >= 1:
                      node = node.children[0]
-                     xnode = netconf.netconf_to_xnode(node, [], 0)
+                     xnode = netconf.netconf_to_xnode(node, [], OP_MERGE)
                      log.trace("SUBSCRIBER netconf-get-poll POLL:", {"xnode": xnode})
                      source_params = tnode_root()
                      source_params_try_append_dev_sub(source_params, dev_sub_key)
-                     source_params.leaf(None, PTag(None, 'timestamp'), request_ts)
+                     source_params.leaf(None, SOURCE_PARAM_TIMESTAMP, request_ts)
                      if schema_path is not None:
-                         source_params.leaf(None, PTag(None, 'schema_path'), schema_path)
+                         source_params.leaf(None, SOURCE_PARAM_SCHEMA_PATH, schema_path)
                      sinks.write(xnode, source_params)
         else:
             pass
@@ -544,12 +603,12 @@ actor NetconfGetPollSubscription(source: NetconfSource, dev_sub_key: Keypath, sh
 
     #def update_sinks(sink_updates: list[(Keypath, ?SubscriptionSink)]):
     def update_config(update: SubscriptionUpdate):
-        sinks.update(update.sinks)
+        sinks.update_added(update.sinks)
 
         __config = update.config
         if __config is not None:
             _config: SubscriptionSourceConfig = __config
-            _stop_poller()
+            DelegateWorker_try_restart_inner(worker_state)
             log.debug("SUBSCRIBER netconf-get-poll CONFIG", {"_config": _config})
 
             poll = _config.config[SUBSCRIPTION_TYPE_KEY_GET_POLLER]
@@ -566,10 +625,10 @@ actor NetconfGetPollSubscription(source: NetconfSource, dev_sub_key: Keypath, sh
             if period_ms is not None and get_xml is not None:
                 period = time.Duration(period_ms // 10**3, (period_ms % 10**3) * 10**15, time.MonotonicClock(0, 0, 0))
                 log.debug("period: " + str(period.to_float()) + "s", None)
-                if is_running:
-                    _try_start_poller()
             else:
                 pass # TODO: Indicate config error
+
+        sinks.update_removed(update.sinks)
 
     def _update_get_params(get_path: Keypath, schema_settings: SchemaSettings):
         _get_xml: ?xml.Node = None
@@ -635,31 +694,45 @@ actor NetconfGetPollSubscription(source: NetconfSource, dev_sub_key: Keypath, sh
         get_xml = _get_xml
         schema_path = _schema_path
 
-    def _try_start_poller():
-        log.debug("SUBSCRIBER netconf-get-poll TRY_START", None)
+    def _start():
+        log.debug("SUBSCRIBER netconf-get-poll START", None)
         log.debug("SUBSCRIBER netconf-get-poll GET_XML", {"get_xml": optional_str(get_xml, "None")})
         if get_xml is not None:
             curr_ts = time.monotonic()
-            # TODO: reduce to after 0. But we're currently getting an error, the
-            # SSH client process is closed with exit code 7 with a delay 0
-            # SSH process exited with code: 7  and termination signal: 0
-            after 5: _do_get_request(poller_seqno, curr_ts)
+            after 0: _do_get_request(poller_seqno, curr_ts)
+        DelegateWorker_on_inner_started(worker_state)
 
-    def _stop_poller():
+    def _stop():
+        log.debug("SUBSCRIBER netconf-get-poll STOP", None)
+
+        # stop poller
         poller_seqno += 1
 
-    def start():
-        if not is_running:
-            log.info("SUBSCRIBER netconf-get-poll STARTED", None)
-            is_running = True
-            _try_start_poller()
+        # write RESET
+        cleanup_payload = XTree(OP_NOCREATE, ITag.root(), None, []) # TODO
+        source_params = tnode_root()
+        source_params_try_append_dev_sub(source_params, dev_sub_key)
+        source_params.leaf(None, SOURCE_PARAM_TIMESTAMP, time.time())
+        if schema_path is not None:
+            source_params.leaf(None, SOURCE_PARAM_SCHEMA_PATH, schema_path)
+        source_params.leaf(None, SOURCE_PARAM_RESET, None)
+        sinks.write(cleanup_payload, source_params, _on_sink_reset)
 
-    def stop():
-        if is_running:
-            log.info("SUBSCRIBER netconf-get-poll STOPPED", None)
-            is_running = False
-            _stop_poller()
+    def _on_sink_reset():
+        log.trace("SUBSCRIBER netconf-get-poll SINK RESET DONE", None)
+        DelegateWorker_on_inner_stopped(worker_state)
 
-    def close():
-        stop()
-        log.info("DEVICE netconf-get-poll CLOSED", None)
+    def set_target_state(target_state: int):
+        log.debug("SUBSCRIBER netconf-get-poll SET TARGET STATE", {"target_state": state_str(target_state)})
+        if not DelegateWorker_set_target_state(worker_state, target_state):
+            log.error("SUBSCRIBER netconf-get-poll UNEXPECTED STATE ignoring", {"target_state": state_str(target_state)})
+
+    def on_reached_state(state: int):
+        log.info("SUBSCRIBER netconf-get-poll REACHED STATE " + state_str(state), None)
+        reached_state_cb(state)
+
+    # Workaround compiler ordering issue
+    worker_state._start_fn = _start
+    worker_state._stop_fn = _stop
+    worker_state._reached_state_cb = on_reached_state
+

--- a/src/telemetrify/main/source/vmanage.act
+++ b/src/telemetrify/main/source/vmanage.act
@@ -1,3 +1,16 @@
+# Copyright (C) Deutsche Telekom AG
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
 import logging
 import http
 import net
@@ -14,7 +27,12 @@ from telemetrify.main.common import *
 from telemetrify.main.config import *
 import telemetrify.vmanage.vmanage as vmanage
 
-actor VManageSource(auth: WorldCap, shared_schema: schema.SharedSchema, log_handler: ?logging.Handler):
+actor VManageSource(
+        reached_state_cb: action(int) -> None,
+        auth: WorldCap,
+        shared_schema: schema.SharedSchema,
+        log_handler: ?logging.Handler):
+
     var logh = logging.Handler("vmanage-source")
     if log_handler is not None:
         logh.set_handler(log_handler)
@@ -24,112 +42,52 @@ actor VManageSource(auth: WorldCap, shared_schema: schema.SharedSchema, log_hand
     var config: TNode = tnode_empty()
     var client: ?vmanage.VManageHTTPClient = None
     var client_seqno: int = 0
-    var subscribers: dict[Keypath, Subscriber] = {}
+    # var manager: DelegateMiddleManager[Subscriber] = DelegateMiddleManager(on_reached_state, _on_subscriber_reached_state_trampoline, _connect_client, _close_client)
+    # Workaround compiler ordering issue
+    var manager: DelegateMiddleManager[Subscriber] = DelegateMiddleManager(lambda s: None, lambda i, s: None, lambda: None, lambda: None)
 
     log.info("SOURCE vmanage CREATED", None)
 
-    def _on_client_connect(seqno: int):
-        if seqno != client_seqno:
-            return
-        _start_subscribers()
-
-    def _on_client_error(error_msg: str, seqno: int):
-        if seqno != client_seqno:
-            return
-        _close_client()
-        # TODO: Configurable retry timer/backoff?
-        after 1: _connect_client()
-
-    def _on_client_notif(node: xml.Node, seqno: int):
-        # if seqno != client_seqno:
-        #     return
-        pass
-
     def update_config(source_update: ?TNode, subscription_updates: list[(Keypath, ?SubscriptionUpdate)]):
         log.debug("SOURCE vmanage CONFIG update", {"source_update": optional_str(source_update, "None")})
-        log.debug("SOURCE vmanage SUBSCRIPTION update", {"subsription_updates": subscription_updates})
+        log.debug("SOURCE vmanage SUBSCRIPTION update", {"subscription_updates": subscription_updates})
 
         restart = False
 
         if source_update is not None:
-            if _close_client():
-                restart = True
-
             config = source_update
-
-            _connect_client()
+            DelegateMiddleManager_try_restart_inner(manager)
 
         for dev_sub_key, sub_update in subscription_updates:
             if sub_update is not None:
-                sub = try_get(subscribers, dev_sub_key)
+                log.trace("SOURCE vmanage SUBSCRIPTION update", {"sub_update": sub_update})
+                # sub = manager.try_get_delegate(dev_sub_key)
+                sub = DelegateMiddleManager_try_get_delegate(manager, dev_sub_key) # https://github.com/actonlang/acton/issues/1448
+
                 if sub is not None:
+                    log.trace("SOURCE vmanage SUBSCRIPTION update exists", {"sub_update": sub_update})
                     sub.update_config(sub_update)
                 else:
+                    log.trace("SOURCE vmanage SUBSCRIPTION update is new", {"sub_update": sub_update})
                     new_sub = _create_subscriber(dev_sub_key, sub_update)
-                    new_sub.update_config(sub_update)
-                    if not restart and client is not None:
-                        new_sub.start()
-                    subscribers[dev_sub_key] = new_sub
             else:
-                sub = try_pop(subscribers, dev_sub_key)
-                if sub is not None:
-                    sub.close()
-
-        if restart:
-            _start_subscribers()
+                # manager.remove_delegate(dev_sub_key)
+                DelegateMiddleManager_remove_delegate(manager, dev_sub_key) # https://github.com/actonlang/acton/issues/1448
 
     def _create_subscriber(dev_sub_key: Keypath, sub_update: SubscriptionUpdate) -> Subscriber:
         sub_config = sub_update.config
         if sub_config is not None:
             _config = sub_config.config
             if _config[SUBSCRIPTION_TYPE_KEY_VMANAGE_POLLER].exists():
-                sub_act = VManagePollSubscription(self, dev_sub_key, shared_schema, logh)
-                return Subscriber(sub_act.update_config, sub_act.start, sub_act.stop, sub_act.close)
+                # _id, reached_state_cb = manager.reserve_delegate(dev_sub_key)
+                _id, _reached_state_cb = DelegateMiddleManager_reserve_delegate(manager, dev_sub_key) # https://github.com/actonlang/acton/issues/1448
+                sub_act = VManagePollSubscription(self, dev_sub_key, _reached_state_cb, shared_schema, logh)
+                sub = Subscriber(sub_act.set_target_state, sub_act.update_config)
+                # manager.add_delegate(_id, sub)
+                DelegateMiddleManager_add_delegate(manager, _id, sub, lambda s: s.update_config(sub_update)) # https://github.com/actonlang/acton/issues/1448
+                return sub
 
         raise Exception("Broken invariant: Attempted to create subscriber from invalid config: " + optional_str(sub_config, "None"))
-
-    def _connect_client():
-        address = config[PTag('tlm', 'address')].try_str()
-        port = config[PTag('tlm', 'port')].try_int()
-        username = config[PTag('tlm', 'username')].try_str()
-        password = config[PTag('tlm', 'password')].try_str()
-
-        if address is not None and port is not None and \
-                username is not None and password is not None:
-
-            client_seqno += 1
-
-            def __on_client_connect(_c):
-                _on_client_connect(client_seqno)
-            #def __on_client_error(_c, e):
-            #    _on_client_error(e, client_seqno)
-
-            tcpccap = net.TCPConnectCap(net.TCPCap(net.NetCap(auth)))
-            new_client = vmanage.VManageHTTPClient(tcpccap, address, port, username, password, __on_client_connect, logh)
-            client = new_client
-
-        # # <TEST>
-        # client_seqno += 1
-        # after 0: _on_client_connect(client_seqno)
-        # # </TEST>
-
-    def _close_client() -> bool:
-        _client = client
-        if _client is not None:
-            _stop_subscribers()
-            # TODO: Gather stop replies from subscribers before closing netconf client?
-            _client.close()
-            client = None
-            return True
-        return False
-
-    def _start_subscribers():
-        for subscriber in subscribers.values():
-            subscriber.start()
-
-    def _stop_subscribers():
-        for subscriber in subscribers.values():
-            subscriber.stop()
 
     def get(path: str, cb: action(?http.Response) -> None) -> None:
         if client is not None:
@@ -137,18 +95,93 @@ actor VManageSource(auth: WorldCap, shared_schema: schema.SharedSchema, log_hand
                 cb(n)
             client.get(path, __callback)
 
-    def close():
+    def _on_client_connect(c, seqno: int):
+        if seqno != client_seqno:
+            c.close()
+            return
+        DelegateMiddleManager_on_inner_started(manager)
+
+    def _on_client_defunct(error_msg: str, seqno: int):
+        if seqno != client_seqno:
+            return
+        _close_client()
+
+        def _retry_client():
+            if manager.target_state == STATE_RUNNING:
+                _connect_client()
+
+        # TODO: Configurable retry timer/backoff?
+        after 1: _retry_client()
+
+    def _connect_client():
+        if client is not None:
+            return
+
+        address = config[PTag('tlm', 'address')].try_str()
+        port = config[PTag('tlm', 'port')].try_int()
+        username = config[PTag('tlm', 'username')].try_str()
+        password = config[PTag('tlm', 'password')].try_str()
+
+        log.debug("SOURCE vmanage CONNECT", {"address": optional_str(address, "None"), "port": optional_str(port, "None"), "username": optional_str(username, "None"), "password": optional_str(password, "None")})
+
+        if address is not None and port is not None and \
+                username is not None and password is not None:
+
+            client_seqno += 1
+
+            def __on_client_connect(c):
+                _on_client_connect(c, client_seqno)
+            #def __on_client_error(_c, e):
+            #    _on_client_error(e, client_seqno)
+
+            tcpccap = net.TCPConnectCap(net.TCPCap(net.NetCap(auth)))
+            new_client = vmanage.VManageHTTPClient(tcpccap, address, port, username, password, __on_client_connect, logh)
+            client = new_client
+
+            # # <TEST>
+            # def _pretend_connect():
+            #     log.debug("SOURCE vmanage CONNECTED (pretending)", None)
+            #     DelegateMiddleManager_on_inner_started(manager)
+            # after 0: _pretend_connect()
+            # # </TEST>
+
+    def _close_client():
+        log.debug("SOURCE vmanage DISCONNECT", None)
+
         _client = client
         if _client is not None:
+            client_seqno += 1
             _client.close()
             client = None
-        for subscriber in subscribers.values():
-            subscriber.close()
-        #subscribers.clear()
-        subscribers = {}
-        log.info("SOURCE vmanage CLOSED", None)
+        DelegateMiddleManager_on_inner_stopped(manager)
 
-actor VManagePollSubscription(source: VManageSource, dev_sub_key: Keypath, shared_schema: schema.SharedSchema, log_handler: logging.Handler):
+    def set_target_state(target_state: int):
+        log.debug("SOURCE vmanage SET TARGET STATE", {"target_state": state_str(target_state)})
+        if not DelegateMiddleManager_set_target_state(manager, target_state):
+            log.error("SOURCE vmanage UNEXPECTED STATE ignoring", {"target_state": state_str(target_state)})
+
+    def on_reached_state(state: int):
+        log.info("SUBSCRIBER vmanage REACHED STATE " + state_str(state), None)
+        reached_state_cb(state)
+
+    def _on_subscriber_reached_state_trampoline(_id: DelegateId, state: int):
+        # manager.on_delegate_reached_state(_id, state)
+        DelegateMiddleManager_on_delegate_reached_state(manager, _id, state) # https://github.com/actonlang/acton/issues/1448
+
+    # Workaround compiler ordering issue
+    manager._start_fn = _connect_client
+    manager._stop_fn = _close_client
+    manager._reached_state_cb = on_reached_state
+    manager._delegate_manager._on_delegate_reached_state_trampoline_fn = _on_subscriber_reached_state_trampoline
+
+
+actor VManagePollSubscription(
+        source: VManageSource,
+        dev_sub_key: Keypath,
+        reached_state_cb: action(int) -> None,
+        shared_schema: schema.SharedSchema,
+        log_handler: logging.Handler):
+
     var logh = logging.Handler("vmanage-poll-subscription")
     if log_handler is not None:
         logh.set_handler(log_handler)
@@ -163,7 +196,9 @@ actor VManagePollSubscription(source: VManageSource, dev_sub_key: Keypath, share
     var schema_path: ?SchemaPath = None
     var period: time.Duration = time.Duration(60, 0, time.MonotonicClock(0, 0, 0))
 
-    var is_running: bool = False
+    # var worker_state = DelegateWorker(on_reached_state, _on_start, _on_stop)
+    # Workaround compiler ordering issue
+    var worker_state = DelegateWorker(lambda s: None, lambda: None, lambda: None)
 
     log.info("SUBSCRIBER vmanage-poll CREATED", None)
 
@@ -226,15 +261,18 @@ actor VManagePollSubscription(source: VManageSource, dev_sub_key: Keypath, share
                     xnode = vmanage.approute_to_xnode(ar_data)
                     source_params = tnode_root()
                     source_params_try_append_dev_sub(source_params, dev_sub_key)
-                    source_params.leaf(None, PTag(None, 'timestamp'), request_ts)
+                    source_params.leaf(None, SOURCE_PARAM_TIMESTAMP, request_ts)
                     if schema_path is not None:
-                        source_params.leaf(None, PTag(None, 'schema_path'), schema_path)
+                        source_params.leaf(None, SOURCE_PARAM_SCHEMA_PATH, schema_path)
                     sinks.write(xnode, source_params)
             except Exception as exc:
                 log.error("Exception", {"exception": exc})
                 log.debug("Reply body", {"body": reply.body})
 
         _schedule_next_poll(seqno, last_ts)
+
+    def _stop_cleanup():
+        pass # TODO
 
     def _schedule_next_poll(seqno: int, last_ts: time.Instant):
         curr_ts = time.monotonic()
@@ -253,11 +291,11 @@ actor VManagePollSubscription(source: VManageSource, dev_sub_key: Keypath, share
         after delay.to_float(): _do_poll(seqno, next_ts)
 
     def update_config(update: SubscriptionUpdate):
-        sinks.update(update.sinks)
+        sinks.update_added(update.sinks) # Postpone removal of sinks for possible cleanup
 
         _config = update.config
         if _config is not None:
-            _stop_poller()
+            DelegateWorker_try_restart_inner(worker_state)
 
             poll = _config.config[SUBSCRIPTION_TYPE_KEY_VMANAGE_POLLER]
             path = poll[PTag('tlm', 'path')].try_str()
@@ -273,8 +311,8 @@ actor VManagePollSubscription(source: VManageSource, dev_sub_key: Keypath, share
 
             if period_ms is not None and poll_path is not None:
                 period = time.Duration(period_ms // 10**3, (period_ms % 10**3) * 10**15, time.MonotonicClock(0, 0, 0))
-                if is_running:
-                    _try_start_poller()
+
+        sinks.update_removed(update.sinks) # Remove after possible sink cleanup
 
     def _update_schema_cursor(kpath: Keypath, schema_settings: SchemaSettings):
         cursor = schema.Cursor(_schema)
@@ -287,26 +325,40 @@ actor VManagePollSubscription(source: VManageSource, dev_sub_key: Keypath, share
                         cursor.set_mount_id(ned_id)
                 schema_path = cursor.get_schema_path()
 
-    def _try_start_poller():
+    def _start():
         if poll_path is not None:
             curr_ts = time.monotonic()
             after 0: _do_poll(poller_seqno, curr_ts)
+        DelegateWorker_on_inner_started(worker_state)
 
-    def _stop_poller():
+    def _stop():
+        # stop poller
         poller_seqno += 1
 
-    def start():
-        if not is_running:
-            log.info("SUBSCRIBER vmanage-poll STARTED", None)
-            is_running = True
-            _try_start_poller()
+        # write RESET
+        dummy_payload = XTree(OP_NOCREATE, ITag.root(), None, [])
+        source_params = tnode_root()
+        source_params_try_append_dev_sub(source_params, dev_sub_key)
+        source_params.leaf(None, SOURCE_PARAM_TIMESTAMP, time.time())
+        if schema_path is not None:
+            source_params.leaf(None, SOURCE_PARAM_SCHEMA_PATH, schema_path)
+        source_params.leaf(None, SOURCE_PARAM_RESET, None)
+        sinks.write(dummy_payload, source_params, _on_sink_reset)
 
-    def stop():
-        if is_running:
-            log.info("SUBSCRIBER vmanage-poll STOPPED", None)
-            is_running = False
-            _stop_poller()
+    def _on_sink_reset():
+        log.trace("SUBSCRIBER vmanage-poll SINK RESET DONE", None)
+        DelegateWorker_on_inner_stopped(worker_state)
 
-    def close():
-        stop()
-        log.info("SUBSCRIBER vmanage-poll CLOSED", None)
+    def set_target_state(target_state: int):
+        log.debug("SUBSCRIBER vmanage-poll SET TARGET STATE", {"target_state": state_str(target_state)})
+        if not DelegateWorker_set_target_state(worker_state, target_state):
+            log.error("SUBSCRIBER vmanage-poll UNEXPECTED STATE ignoring", {"target_state": state_str(target_state)})
+
+    def on_reached_state(state: int):
+        log.info("SUBSCRIBER vmanage-poll REACHED STATE " + state_str(state), None)
+        reached_state_cb(state)
+
+    # Workaround compiler ordering issue
+    worker_state._start_fn = _start
+    worker_state._stop_fn = _stop
+    worker_state._reached_state_cb = on_reached_state

--- a/src/telemetrify/main/test/common.act
+++ b/src/telemetrify/main/test/common.act
@@ -1,0 +1,381 @@
+# Copyright (C) Deutsche Telekom AG
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+import logging
+import testing
+
+from telemetrify.common.mod import *
+from telemetrify.common.utils import *
+from telemetrify.main.common import *
+
+class EventTester(object):
+    @property
+    _expected_events: list[str]
+    @property
+    __prev_index: int
+    @property
+    __curr_index: int
+    @property
+    __next_index: int
+    @property
+    _actual_events: list[str]
+    @property
+    __next_step: ?action() -> None
+    @property
+    report_result: action(?bool, ?Exception) -> None
+
+    def __init__(self, report_result: action(?bool, ?Exception) -> None):
+        self.report_result = report_result
+        #self.reset()
+        self._expected_events = []
+        self.__prev_index = 0
+        self.__curr_index = 0
+        self.__next_index = 0
+        self._actual_events = []
+        self.__next_step = None
+
+    def reset(self):
+        self._expected_events = []
+        self.__prev_index = 0
+        self.__curr_index = 0
+        self.__next_index = 0
+        self._actual_events = []
+        self.__next_step = None
+
+    def on_event(self, e: ?str):
+        if e is not None:
+            self._actual_events.append(e)
+            self.__curr_index += 1
+        if self.__curr_index == self.__next_index:
+            if self._actual_events[self.__prev_index:self.__next_index] == self._expected_events[self.__prev_index:self.__next_index]:
+                _next_step: ?action() -> None = self.__next_step
+                if _next_step is not None:
+                    #_next_step()
+                    #after 0: _next_step()
+                    def _f():
+                        _next_step()
+                    after 0: _f()
+                else:
+                    self.report_result(True, None)
+            else:
+                self.report_result(None, AssertionError("Expected events: " + list_str(self._expected_events) + " actual events: " + list_str(self._actual_events)))
+
+    def expect(self, events: list[str], next_step: ?action() -> None):
+        self._expected_events.extend(events)
+        self.__prev_index = self.__next_index
+        self.__next_index += len(events)
+        self.__next_step = next_step
+
+actor DelegateWorkerTester(report_result, log_handler):
+    log = logging.Logger(log_handler)
+
+    var e = EventTester(report_result)
+    var w = DelegateWorker(lambda s: None, lambda: None, lambda: None)
+
+    def _init():
+        e.reset()
+        w = DelegateWorker(on_reached_state, on_start, on_stop)
+
+    def on_reached_state(s):
+        e.on_event(state_str(s))
+
+    def on_start():
+        e.on_event("DO_START")
+        DelegateWorker_on_inner_started(w)
+
+    def on_stop():
+        e.on_event("DO_STOP")
+        DelegateWorker_on_inner_stopped(w)
+
+    def test1():
+        try:
+            _init()
+
+            e.expect(["STOPPED"], None)
+
+            testing.assertTrue(DelegateWorker_set_target_state(w, STATE_STOPPED), "Invalid target state")
+        except Exception as ex:
+            report_result(False, ex)
+
+    def test2():
+        try:
+            _init()
+
+            e.expect(["DO_START", "RUNNING"], test2_1)
+
+            testing.assertTrue(DelegateWorker_set_target_state(w, STATE_RUNNING), "Invalid target state")
+        except Exception as ex:
+            report_result(False, ex)
+
+    def test2_1():
+        try:
+            e.expect(["RUNNING"], test2_2)
+
+            testing.assertTrue(DelegateWorker_set_target_state(w, STATE_RUNNING), "Invalid target state")
+        except Exception as ex:
+            report_result(False, ex)
+
+    def test2_2():
+        try:
+            e.expect(["DO_STOP", "DO_START", "RUNNING"], test2_3)
+
+            DelegateWorker_try_restart_inner(w)
+        except Exception as ex:
+            report_result(False, ex)
+
+    def test2_3():
+        try:
+            e.expect(["DO_STOP", "STOPPED"], test2_4)
+
+            testing.assertTrue(DelegateWorker_set_target_state(w, STATE_STOPPED), "Invalid target state")
+        except Exception as ex:
+            report_result(False, ex)
+
+    def test2_4():
+        try:
+            e.expect(["STOPPED"], None)
+
+            DelegateWorker_try_restart_inner(w) # Expecting NOOP
+            testing.assertTrue(DelegateWorker_set_target_state(w, STATE_STOPPED), "Invalid target state") # Verify STOPPED without any DO_STOP from the above restart
+        except Exception as ex:
+            report_result(False, ex)
+
+    def test3():
+        try:
+            _init()
+
+            e.expect(["CLOSED"], None)
+
+            testing.assertTrue(DelegateWorker_set_target_state(w, STATE_CLOSED), "Invalid target state")
+
+            testing.assertFalse(DelegateWorker_set_target_state(w, STATE_RUNNING), "A closed worker can only be closed")
+
+            testing.assertFalse(DelegateWorker_set_target_state(w, STATE_STOPPED), "A closed worker can only be closed")
+        except Exception as ex:
+            report_result(False, ex)
+
+    def test4():
+        try:
+            _init()
+
+            e.expect(["DO_START", "RUNNING"], test4_1)
+
+            testing.assertTrue(DelegateWorker_set_target_state(w, STATE_RUNNING), "Invalid target state")
+        except Exception as ex:
+            report_result(False, ex)
+
+    def test4_1():
+        try:
+            e.expect(["DO_STOP", "CLOSED"], None)
+
+            ok = DelegateWorker_set_target_state(w, STATE_CLOSED)
+            testing.assertTrue(ok, "Invalid target state")
+        except Exception as ex:
+            report_result(False, ex)
+
+actor DelegateMockActor(reached_state_cb: action(int) -> None):
+    def set_target_state(target_state: int) -> None:
+        reached_state_cb(target_state)
+
+class DelegateMock(object):
+    @property
+    inner: DelegateMockActor
+
+    def __init__(self, inner: DelegateMockActor):
+        self.inner = inner
+
+extension DelegateMock(Delegate):
+    def set_target_state(self, target_state: int) -> None:
+        self.inner.set_target_state(target_state)
+
+actor DelegateMiddleManagerTester(report_result, log_handler):
+    log = logging.Logger(log_handler)
+
+    var e = EventTester(report_result)
+    var m: DelegateMiddleManager[DelegateMock] = DelegateMiddleManager(lambda s: None, lambda i, s: None, lambda: None, lambda: None)
+
+    key0 = Keypath([Key([0])])
+    key1 = Keypath([Key([1])])
+
+    def _init(log_delegates: bool = False):
+        e.reset()
+        m = DelegateMiddleManager(
+            on_reached_state,
+            _on_delegate_reached_state_trampoline_log if log_delegates else _on_delegate_reached_state_trampoline,
+            on_start,
+            on_stop)
+
+    def on_reached_state(s):
+        e.on_event(state_str(s))
+
+    def on_start():
+        e.on_event("DO_START")
+        DelegateMiddleManager_on_inner_started(m)
+
+    def on_stop():
+        e.on_event("DO_STOP")
+        DelegateMiddleManager_on_inner_stopped(m)
+
+    action def _on_delegate_reached_state_trampoline(_id: DelegateId, state: int):
+        DelegateMiddleManager_on_delegate_reached_state(m, _id, state)
+        #raise ValueError("DEBUG " + str(_id) + " " + state_str(state) + " " + str(m._delegate_manager._pending_state_transition))
+
+    action def _on_delegate_reached_state_trampoline_log(_id: DelegateId, state: int):
+        k_str: ?str = None
+        kp = _id.key
+        if len(kp) == 1:
+            k = kp.try_get_key(0)
+            if k is not None:
+                if len(k) == 1:
+                    k_str = str(k[0])
+        e.on_event((k_str if k_str is not None else str(_id.key)) + "-" + str(_id.seqno) + "_" + state_str(state))
+        DelegateMiddleManager_on_delegate_reached_state(m, _id, state)
+
+    def add_delegate(key: Keypath) -> DelegateMock:
+        _id, _reached_state_cb = DelegateMiddleManager_reserve_delegate(m, key)
+        delegate = DelegateMock(DelegateMockActor(_reached_state_cb))
+        DelegateMiddleManager_add_delegate(m, _id, delegate, lambda s: None)
+        return delegate
+
+    def test1():
+        try:
+            _init()
+
+            add_delegate(key0)
+            add_delegate(key1)
+
+            e.expect(["STOPPED"], None)
+
+            testing.assertTrue(DelegateMiddleManager_set_target_state(m, STATE_STOPPED), "Invalid target state")
+        except Exception as ex:
+            report_result(False, ex)
+
+    def test2():
+        try:
+            _init()
+
+            add_delegate(key0)
+            add_delegate(key1)
+
+            e.expect(["DO_START", "RUNNING"], test2_1)
+
+            testing.assertTrue(DelegateMiddleManager_set_target_state(m, STATE_RUNNING), "Invalid target state")
+        except Exception as ex:
+            report_result(False, ex)
+
+    def test2_1():
+        try:
+            e.expect(["RUNNING"], test2_2)
+
+            testing.assertTrue(DelegateMiddleManager_set_target_state(m, STATE_RUNNING), "Invalid target state")
+        except Exception as ex:
+            report_result(False, ex)
+
+    def test2_2():
+        try:
+            e.expect(["DO_STOP", "DO_START", "RUNNING"], test2_3)
+
+            DelegateMiddleManager_try_restart_inner(m)
+        except Exception as ex:
+            report_result(False, ex)
+
+    def test2_3():
+        try:
+            e.expect(["DO_STOP", "STOPPED"], test2_4)
+
+            testing.assertTrue(DelegateMiddleManager_set_target_state(m, STATE_STOPPED), "Invalid target state")
+        except Exception as ex:
+            report_result(False, ex)
+
+    def test2_4():
+        try:
+            e.expect(["STOPPED"], None)
+
+            DelegateMiddleManager_try_restart_inner(m) # Expecting NOOP
+            DelegateMiddleManager_set_target_state(m, STATE_STOPPED) # Verify STOPPED without any DO_STOP from the above restart
+        except Exception as ex:
+            report_result(False, ex)
+
+    def test3():
+        try:
+            _init(True)
+
+            add_delegate(key0)
+
+            e.expect(["DO_START", "RUNNING", "0-0_RUNNING"], test3_1)
+
+            testing.assertTrue(DelegateMiddleManager_set_target_state(m, STATE_RUNNING), "Invalid target state")
+        except Exception as ex:
+            report_result(False, ex)
+
+    def test3_1():
+        try:
+            e.expect(["0-0_CLOSED"], None)
+
+            DelegateMiddleManager_remove_delegate(m, key0)
+        except Exception as ex:
+            report_result(False, ex)
+
+    def test4():
+        try:
+            _init(True)
+
+            add_delegate(key0)
+
+            e.expect(["DO_START", "RUNNING", "0-0_RUNNING"], test4_1)
+
+            testing.assertTrue(DelegateMiddleManager_set_target_state(m, STATE_RUNNING), "Invalid target state")
+        except Exception as ex:
+            report_result(False, ex)
+
+    def test4_1():
+        try:
+            e.expect(["0-0_CLOSED", "0-1_RUNNING"], None)
+
+            DelegateMiddleManager_remove_delegate(m, key0)
+            add_delegate(key0)
+        except Exception as ex:
+            report_result(False, ex)
+
+def _test_async_dummy(report_result, log_handler: logging.Handler) -> None:
+    report_result(True, None)
+
+def _test_env_dummy(report_result, env, log_handler: logging.Handler) -> None:
+    report_result(True, None)
+
+__unit_tests: dict[str, testing.UnitTest] = {
+    "_test_dummy": testing.UnitTest(lambda: None, "dummy", "dummy"),
+}
+
+__sync_actor_tests: dict[str, testing.SyncActorTest] = {
+    "_test_sync_dummy": testing.SyncActorTest(lambda lh: None, "sync_dummy", "sync_dummy"),
+}
+
+__async_actor_tests: dict[str, testing.AsyncActorTest] = {
+    #"_test_async_dummy": testing.AsyncActorTest(_test_async_dummy, "async_dummy", "async_dummy"),
+    "_test_delegate_worker_1": testing.AsyncActorTest(lambda r, lh: DelegateWorkerTester(r, lh).test1(), "DelegateWorker1", "DelegateWorker state transitions #1"),
+    "_test_delegate_worker_2": testing.AsyncActorTest(lambda r, lh: DelegateWorkerTester(r, lh).test2(), "DelegateWorker2", "DelegateWorker state transitions #2"),
+    "_test_delegate_worker_3": testing.AsyncActorTest(lambda r, lh: DelegateWorkerTester(r, lh).test3(), "DelegateWorker3", "DelegateWorker state transitions #3"),
+    "_test_delegate_worker_4": testing.AsyncActorTest(lambda r, lh: DelegateWorkerTester(r, lh).test4(), "DelegateWorker4", "DelegateWorker state transitions #4"),
+    "_test_delegate_middle_manager_1": testing.AsyncActorTest(lambda r, lh: DelegateMiddleManagerTester(r, lh).test1(), "DelegateMiddleManager1", "DelegateMiddleManager state transitions #1"),
+    "_test_delegate_middle_manager_2": testing.AsyncActorTest(lambda r, lh: DelegateMiddleManagerTester(r, lh).test2(), "DelegateMiddleManager2", "DelegateMiddleManager state transitions #2"),
+    "_test_delegate_middle_manager_3": testing.AsyncActorTest(lambda r, lh: DelegateMiddleManagerTester(r, lh).test3(), "DelegateMiddleManager3", "DelegateMiddleManager state transitions #3"),
+    "_test_delegate_middle_manager_4": testing.AsyncActorTest(lambda r, lh: DelegateMiddleManagerTester(r, lh).test4(), "DelegateMiddleManager4", "DelegateMiddleManager state transitions #4"),
+}
+
+__env_tests: dict[str, testing.EnvTest] = {
+    "_test_env_dummy": testing.EnvTest(_test_env_dummy, "env_dummy", "env_dummy"),
+}
+
+actor main(env):
+    testing.test_runner(env, __unit_tests, __sync_actor_tests, __async_actor_tests, __env_tests)

--- a/src/telemetrify/test.act
+++ b/src/telemetrify/test.act
@@ -545,7 +545,7 @@ actor test_tsdb_writer(env: Env, opts: Opts):
         #print("Received reply:\n", xml.encode(n))
         pass
         if n is not None:
-            xnode = telemetrify.net.netconf.netconf_to_xnode(n, [], 0)
+            xnode = telemetrify.net.netconf.netconf_to_xnode(n, [], OP_MERGE)
 
             log.debug("RPC XNode:", {"xnode": xnode})
 

--- a/src/telemetrify/vmanage/transform.act
+++ b/src/telemetrify/vmanage/transform.act
@@ -20,7 +20,7 @@ from telemetrify.common.utils import *
 from telemetrify.ietf.l3vpn_svc import L3vpnSvcParams
 
 actor Transform(
-        output_cb: action(Node, TNode) -> None,
+        output_cb: action(Node, TNode, ?action() -> None) -> None,
         fetch_l3vpn_svc_tracker: action(action(telemetrify.ietf.l3vpn_svc.L3vpnSvcTracker) -> None) -> None,
         release_l3vpn_svc_tracker: action(telemetrify.ietf.l3vpn_svc.L3vpnSvcTracker) -> None,
         log_handler: ?logging.Handler):
@@ -30,11 +30,19 @@ actor Transform(
         logh.set_handler(log_handler)
     var log = logging.Logger(logh)
 
-    tasks: Wardrobe[(list[dict[str, str]], TNode)] = Wardrobe()
+    tasks: Wardrobe[(list[dict[str, str]], TNode, ?action() -> None)] = Wardrobe()
     l3vpn_svc_tracker: ?telemetrify.ietf.l3vpn_svc.L3vpnSvcTracker = None
     pending_fetch_l3vpn_svc_tracker_task_ids: list[int] = []
 
-    def transform(node: Node, source_params: TNode):
+    def transform(node: Node, source_params: TNode, done_cb: ?action() -> None):
+        is_reset = source_params.has_child(PTag(None, 'reset'))
+        if is_reset:
+            _transform_reset(node, source_params, done_cb)
+        else:
+            _transform_update(node, source_params, done_cb)
+
+    def _transform_update(node: Node, source_params: TNode, done_cb: ?action() -> None):
+        log.debug("Transform update", None)
 
         src_ns = 'http://terastrm.net/ns/yang/vmanage'
 
@@ -68,7 +76,7 @@ actor Transform(
                         approutes.append(params)
 
         if approutes:
-            task_id = tasks.put((approutes, source_params))
+            task_id = tasks.put((approutes, source_params, done_cb))
 
             _l3vpn_svc_tracker = l3vpn_svc_tracker
             if _l3vpn_svc_tracker is not None:
@@ -77,12 +85,18 @@ actor Transform(
                 pending_fetch_l3vpn_svc_tracker_task_ids.append(task_id)
                 fetch_l3vpn_svc_tracker(_on_fetched_l3vpn_svc_tracker)
 
+    def _transform_reset(node: Node, source_params: TNode, done_cb: ?action() -> None):
+        log.debug("Transform reset", None)
+        # TODO: ...
+        if done_cb is not None:
+            done_cb()
+
     def _on_lookup_result(params_lookup: dict[IPv4Address, L3vpnSvcParams], task_id: int):
 
         log.debug("lookup", {"result": mapping_str(params_lookup)})
 
         try:
-            approutes, source_params = tasks.pop(task_id)
+            approutes, source_params, done_cb = tasks.pop(task_id)
         except KeyError:
             pass # TODO: debug/trace log?
         else:
@@ -99,7 +113,7 @@ actor Transform(
                     if dst_ip is not None:
                         _create_network_node(root, dst_ip, src_ip, params_lookup, None)
 
-            output_cb(root, source_params)
+            output_cb(root, source_params, done_cb)
 
     def _create_network_node(root, src_ip: IPv4Address, dst_ip: ?IPv4Address, params_lookup: dict[IPv4Address, L3vpnSvcParams], approute: ?dict[str, str]):
         ns = "urn:ietf:params:xml:ns:yang:ietf-network-state"
@@ -187,7 +201,7 @@ actor Transform(
         l3vpn_svc_tracker = _l3vpn_svc_tracker
         for task_id in pending_fetch_l3vpn_svc_tracker_task_ids:
             try:
-                approutes, source_params = tasks.borrow(task_id)
+                approutes, _source_params, _done_cb = tasks.borrow(task_id)
             except KeyError:
                 pass # TODO: debug/trace log?
             else:


### PR DESCRIPTION
For main->device->source->subscription tree actors:
- Unified state management through mixin-ish classes (until actor subtyping support is added to acton)
- Start when upper level has successfully intialized any required resources (e.g. source protocol connection)
- At stop/close each level await lower level actors to complete stop/close.
- New actors reusing the configuration key (e.g. device/source/subscription name) of a previously removed/closed actor hold off startup pending the completed closing (e.g. sink cleanup) of it's predecessor

Reset (cleanup) notification for subscription->transform->sink chains:
- Optional callback to allow awaiting e.g. sink cleanup operations before closing the originating source/subscriber