### PR TITLE
Avoid extra log handler in PRW client

### DIFF
--- a/src/tsdb/prometheus.act
+++ b/src/tsdb/prometheus.act
@@ -54,12 +54,9 @@ def assemble_payload(metrics: list[Metric]) -> bytes:
     #log.debug("send_metric metric_proto", {"metric_proto": metric_proto})
     return snappy.compress(metric_proto)
 
-actor Client(auth: net.TCPConnectCap, address: str, port: int, api_endpoint: str, on_connect: action(Client) -> None, on_error: action(Client, str) -> None, log_handler: ?logging.Handler):
+actor Client(auth: net.TCPConnectCap, address: str, port: int, api_endpoint: str, on_connect: action(Client) -> None, on_error: action(Client, str) -> None, log_handler: ?logging.Handler=None):
 
-    logh = logging.Handler("tsdb.prometheus.Client")
-    if log_handler is not None:
-        logh.set_handler(log_handler)
-    log = logging.Logger(logh)
+    log = logging.Logger(log_handler)
 
     def _on_connect(client: http.Client):
         log.info("TSDB HTTP client connected!", None)


### PR DESCRIPTION
We don't want an extra log handler actor, just a local logger that is using the fed in handler. The purpose of a handler is to be able to collect the logs from multiple actors under a single control (and it's also reflected in the path). With a log handler per Client, we don't really get that, it's just an extra jump for not much gain.

@ciaran2 FYI