### PR TITLE
Use milliseconds for metric timestamp

### DIFF
--- a/src/tsdb/common.act
+++ b/src/tsdb/common.act
@@ -1,11 +1,11 @@
 class Metric(object):
-    @property
+    """Metric
+
+    The timestamps is a Unix timestamp in milliseconds.
+    """
     name: str
-    @property
     tags: dict[str, str]
-    @property
     value: float
-    @property
     timestamp: int
 
     def __init__(self, name: str, tags: dict[str, str], value: float, timestamp: int):

--- a/src/tsdb/prometheus.act
+++ b/src/tsdb/prometheus.act
@@ -45,7 +45,7 @@ def assemble_payload(metrics: list[Metric]) -> bytes:
 
         samples = []
         for metric in metric_series:
-            samples.append((metric.value, metric.timestamp * 1000))
+            samples.append((metric.value, metric.timestamp))
 
         metric_data.append((labels, samples))
 


### PR DESCRIPTION
Also stopped cargo culting `@property` ;)