### PR TITLE
Adapt to f-strings in Acton

### DIFF
--- a/telemetrify-core/src/telemetrify/common/mod.act
+++ b/telemetrify-core/src/telemetrify/common/mod.act
@@ -33,7 +33,7 @@ def op_str(op: int) -> str:
     elif op == OP_NOCREATE:
         return "NOCREATE"
     else:
-        raise Exception("Not Implemented for op: " + str(op))
+        raise Exception(f"Not Implemented for op: {op}")
 
 class Id:
     pass
@@ -57,10 +57,10 @@ class ITag(Tag):
 
     def __str__(self) -> str:
         _ns = self.ns
-        return _ns + ":" + self.name if _ns is not None else self.name
+        return f"{_ns}:{self.name}" if _ns is not None else self.name
 
     def __repr__(self) -> str:
-        return "ITag(%s, %s)" % (optional_repr(self.ns), repr(self.name))
+        return f"ITag({optional_repr(self.ns)}, {repr(self.name)})"
 
     @staticmethod
     def root() -> ITag:
@@ -79,8 +79,8 @@ class ITag(Tag):
 
     def prsrc(self) -> str:
         _ns = self.ns
-        s_ns = '"' + _ns + '"' if _ns is not None else "None"
-        return 'ITag(' + s_ns + ', "' + self.name + '")'
+        s_ns = f'"{_ns}"' if _ns is not None else "None"
+        return f'ITag({s_ns}, "{self.name}")'
 
 extension ITag(Hashable):
     def __eq__(self, other: ITag) -> bool:
@@ -105,10 +105,10 @@ class PTag(Tag):
 
     def __str__(self) -> str:
         _prefix = self.prefix
-        return _prefix + ":" + self.name if _prefix is not None else self.name
+        return f"{_prefix}:{self.name}" if _prefix is not None else self.name
 
     def __repr__(self) -> str:
-        return "PTag(%s, %s)" % (optional_repr(self.prefix), repr(self.name))
+        return f"PTag({optional_repr(self.prefix)}, {repr(self.name)})"
 
     @staticmethod
     def root() -> PTag:
@@ -141,10 +141,10 @@ class MTag(Tag):
 
     def __str__(self) -> str:
         _module = self.module
-        return _module + ":" + self.name if _module is not None else self.name
+        return f"{_module}:{self.name}" if _module is not None else self.name
 
     def __repr__(self) -> str:
-        return "MTag(%s, %s)" % (optional_repr(self.module), repr(self.name))
+        return f"MTag({optional_repr(self.module)}, {repr(self.name)})"
 
     @staticmethod
     def root() -> MTag:
@@ -179,7 +179,7 @@ class HTag(Tag):
         return self.__repr__()
 
     def __repr__(self) -> str:
-        return "HTag(%s, %s)" % (repr(self.ns_hash), repr(self.name_hash))
+        return f"HTag({repr(self.ns_hash)}, {repr(self.name_hash)})"
 
     @staticmethod
     def root() -> HTag:
@@ -235,7 +235,7 @@ def _eq_value(a: value, b: value) -> bool:
         return a == b
     elif isinstance(a, Oid) and isinstance(b, Oid):
         return a == b
-    raise Exception("_eq_value: Not Implemented for types " + str(type(a)) + " == " + str(type(b)))
+    raise Exception(f"_eq_value: Not Implemented for types {type(a)} == {type(b)}")
 
 def _hash_value(v: value) -> int:
     # Looks like we need to do this for now?
@@ -279,7 +279,7 @@ def _hash_value(v: value) -> int:
         return hash(v)
     elif isinstance(v, list): # Leaf-list for completeness although not valid for keys
         return list_hash(v)
-    raise Exception("_hash_value: Not Implemented for type: " + str(type(v)) + " of value: " + str(v))
+    raise Exception(f"_hash_value: Not Implemented for type: {type(v)} of value: {v}")
 
 class Key(Id):
     _keys: list[value]
@@ -288,7 +288,7 @@ class Key(Id):
         self._keys = keys
 
     def __str__(self) -> str:
-        return "Key(" + list_str(self._keys) + ")"
+        return f"Key({self._keys})"
 
     def __repr__(self):
         return self.__str__()
@@ -359,7 +359,7 @@ class Keypath:
         return "".join(l)
 
     def __repr__(self):
-        return "Keypath(" + self.__str__() + ")"
+        return f"Keypath({self.__str__()})"
 
     def try_get_key(self, index: int) -> ?Key:
         if index < len(self):
@@ -472,18 +472,18 @@ class Node(object):
 
     def _str_compact(self, name: str) -> str:
         _tag = self.tag()
-        s_tag = (", " + str(_tag)) if _tag is not None else ""
+        s_tag = f", {_tag}" if _tag is not None else ""
 
         _keys = self.keys()
-        s_keys = (", " + list_str(_keys)) if _keys else ""
+        s_keys = f", {_keys}" if _keys else ""
 
         _value = self.value()
-        s_value = (", " + str(_value)) if _value is not None else ""
+        s_value = f", {_value}" if _value is not None else ""
 
         _children = self.children()
-        s_children = (", " + list_str(_children)) if _children else ""
+        s_children = f", {_children}" if _children else ""
 
-        return name + "(" + op_str(self.op()) + s_tag + s_keys + s_value + s_children + ")"
+        return f"{name}({op_str(self.op())}{s_tag}{s_keys}{s_value}{s_children})"
 
     def op(self) -> int:
         return OP_NONE
@@ -515,18 +515,18 @@ class Node(object):
 
     def _pretty_format_node_tree(self, parts: list[str], indent: str):
         _tag = self.tag()
-        s_tag = (", " + repr(_tag)) if _tag is not None else ""
+        s_tag = f", {repr(_tag)}" if _tag is not None else ""
 
         _keys = self.keys()
-        s_keys = (", keys=" + list_repr(_keys)) if _keys else ""
+        s_keys = f", keys={list_repr(_keys)}" if _keys else ""
 
         _value = self.value()
-        s_value = (", val=" + repr(_value)) if _value is not None else ""
+        s_value = f", val={repr(_value)}" if _value is not None else ""
 
-        parts.append(indent + "Node(" + op_str(self.op()) + s_tag + s_keys + s_value + ")\n")
+        parts.append(f"{indent}Node({op_str(self.op())}{s_tag}{s_keys}{s_value})\n")
 
         for child in self.children():
-            child._pretty_format_node_tree(parts, indent + "  ")
+            child._pretty_format_node_tree(parts, f"{indent}  ")
 
 class XNode(Node):
     @property
@@ -579,21 +579,21 @@ class XTree(XNode):
     def prsrc(self, indent: int) -> str:
         """Print source code of self and call children"""
         _tag = self._tag
-        s_tag = ", " + (_tag.prsrc() if _tag is not None else "None")
+        s_tag = f", {_tag.prsrc() if _tag is not None else 'None'}"
         children_strs = []
         for child in self._children:
             children_strs.append(child.prsrc(indent+1))
 
         _ns = self._namespaces
         # TODO: implement support for printing namespaces!?
-        s_ns = ", " + "None"
+        s_ns = ", None"
 
-        s_children = ", [\n" + ",\n".join(children_strs) + "]"
+        s_children = f", [\n{',\n'.join(children_strs)}]"
 
         s_indent = ""
         for i in range(0, indent, 1):
-            s_indent += "    "
-        return s_indent + "XTree(OP_" + op_str(self._op) + s_tag + s_ns + s_children + ")"
+            s_indent = f"{s_indent}    "
+        return f"{s_indent}XTree(OP_{op_str(self._op)}{s_tag}{s_ns}{s_children})"
 
 class XLeaf(XNode):
     @property
@@ -618,19 +618,19 @@ class XLeaf(XNode):
     def prsrc(self, indent: int) -> str:
         """Print source code"""
         _tag = self._tag
-        s_tag = ", " + (_tag.prsrc() if _tag is not None else "None")
+        s_tag = f", {_tag.prsrc() if _tag is not None else 'None'}"
 
         _ns = self._namespaces
         # TODO: implement support for printing namespaces!?
-        s_ns = ", " + "None"
+        s_ns = ", None"
 
         _val = self._value
-        s_val = ', "' + str(_val) + '"' if _val is not None else "None"
+        s_val = f', "{_val}"' if _val is not None else "None"
 
         s_indent = ""
         for i in range(0, indent, 1):
-            s_indent += "    "
-        return s_indent + "XLeaf(OP_" + op_str(self._op) + s_tag + s_ns + s_val + ")"
+            s_indent = f"{s_indent}    "
+        return f"{s_indent}XLeaf(OP_{op_str(self._op)}{s_tag}{s_ns}{s_val})"
 
 class TNode(Node):
     @property
@@ -1067,14 +1067,12 @@ class TTree(TNode):
 
     def __str__(self) -> str:
         _tag = self.tag()
-        s_tag = ", " + str(_tag) if _tag is not None else ""
+        s_tag = f", {_tag}" if _tag is not None else ""
 
         _keys = self.keys()
-        s_keys = ", " + list_str(_keys) if _keys else ""
+        s_keys = f", {_keys}" if _keys else ""
 
-        s_children = ", " + mapping_str(self._children)
-
-        return "TTree(" + op_str(self.op()) + s_tag + s_keys + s_children + ")"
+        return f"TTree({op_str(self.op())}{s_tag}{s_keys}, {self._children})"
 
     #
     # TNode
@@ -1426,7 +1424,7 @@ extension Id(Hashable):
         elif isinstance(self, Key):
             return isinstance(other, Key) and self == other
         else:
-            raise Exception("Id.__eq__: Not Implemented for types " + str(type(self)) + " == " + str(type(other)))
+            raise Exception(f"Id.__eq__: Not Implemented for types {type(self)} == {type(other)}")
 
     def __hash__(self):
         if isinstance(self, Tag):
@@ -1434,7 +1432,7 @@ extension Id(Hashable):
         elif isinstance(self, Key):
             return hash(self)
         else:
-            raise Exception("Id.__hash__: Not Implemented for type: " + type(self))
+            raise Exception(f"Id.__hash__: Not Implemented for type: {type(self)}")
 
 extension Tag(Hashable):
     def __eq__(self, other: Id):
@@ -1447,7 +1445,7 @@ extension Tag(Hashable):
         elif isinstance(self, HTag) and isinstance(other, HTag):
             return self == other
         else:
-            raise Exception("Tag.__eq__: Not Implemented for types " + str(type(self)) + " == " + str(type(other)))
+            raise Exception(f"Tag.__eq__: Not Implemented for types {type(self)} == {type(other)}")
 
     def __hash__(self):
         if isinstance(self, ITag):
@@ -1459,7 +1457,7 @@ extension Tag(Hashable):
         elif isinstance(self, HTag):
             return hash(self)
         else:
-            raise Exception("Tag.__hash__: Not Implemented for type: " + type(self))
+            raise Exception(f"Tag.__hash__: Not Implemented for type: {type(self)}")
 
 extension Keypath(Hashable):
     def __eq__(self, other) -> bool:

--- a/telemetrify-core/src/telemetrify/common/utils.act
+++ b/telemetrify-core/src/telemetrify/common/utils.act
@@ -352,14 +352,6 @@ def get_or_create[A(Hashable), B](m: dict[A, B], a: A, b: () -> B) -> B:
     m[a] = c
     return c
 
-def mapping_str[A(Eq), B](m: Mapping[A, B]) -> str:
-    l: list[str] = []
-    #for k, v in m.items():
-    for p in m.items():
-        k, v = p
-        unsafe_list_append(l, str(k) + ": " + str(v))
-    return "{" + ", ".join(l) + "}"
-
 def list_pop[T](l: list[T]) -> T:
     res = l[-1]
     del l[-1]
@@ -411,23 +403,17 @@ def list_reversed[T](a: list[T]) -> list[T]:
     r.reverse()
     return r
 
-def list_str[T](a: list[T]) -> str:
-    l: list[str] = []
-    for x in a:
-        unsafe_list_append(l, str(x))
-    return "[" + ", ".join(l) + "]"
-
 def list_repr[T](a: list[T]) -> str:
     l: list[str] = []
     for x in a:
         unsafe_list_append(l, repr(x))
-    return "[" + ", ".join(l) + "]"
+    return f"[{', '.join(l)}]"
 
 def list_optional_repr[T](a: list[?T]) -> str:
     l: list[str] = []
     for x in a:
         unsafe_list_append(l, optional_repr(x))
-    return "[" + ", ".join(l) + "]"
+    return f"[{', '.join(l)}]"
 
 def set_update[T(Hashable)](target: set[T], source: Iterable[T]):
     for item in source:
@@ -446,12 +432,6 @@ def set_intersection[T(Hashable)](self: set[T], other: set[T]):
         if item in other:
             result.add(item)
     return result
-
-def set_str[T(Hashable)](a: set[T]) -> str:
-    l: list[str] = []
-    for x in a:
-        unsafe_list_append(l, str(x))
-    return "{" + ", ".join(l) + "}"
 
 def dict_list_append[K(Hashable), V](d: dict[K, list[V]], k: K, v: V):
     l = try_get(d, k)
@@ -843,7 +823,7 @@ def try_parse_hex(s: str) -> ?int:
 
 def to_byte_hexpair_str(v: int) -> str:
     # return nibble_to_hex(v >> 4 & 0xF) + nibble_to_hex(v & 0xF) # BUG: Runtime error on bitwise operations
-    return nibble_to_hex((v // 0x10) % 0x10) + nibble_to_hex(v % 0x10)
+    return f"{nibble_to_hex((v // 0x10) % 0x10)}{nibble_to_hex(v % 0x10)}"
 
 def nibble_to_hex(v: int) -> str:
     if v == 0:
@@ -886,7 +866,7 @@ def to_n_dec_str(v: int, min_dec: int) -> str:
     sl = []
     for i in range(0, min_dec - len(s), 1):
         unsafe_list_append(sl, "0")
-    return "".join(sl) + s
+    return f"{''.join(sl)}{s}"
 
 def uint_to_bytes_le(v: int) -> bytes:
     if v < 0:
@@ -988,7 +968,7 @@ class IPv4Address(object):
 
     def __str__(self) -> str:
         d = self.data
-        return str(d.0) + "." + str(d.1) + "." + str(d.2) + "." + str(d.3)
+        return f"{d.0}.{d.1}.{d.2}.{d.3}"
 
     def __repr__(self):
         return self.__str__() # TODO: Proper repr
@@ -1024,8 +1004,8 @@ class IPv6Address(object):
     def __str__(self) -> str:
         # TODO: conventional format
         d = self.data
-        return hex(d.0) + ":" + hex(d.1) + ":" + hex(d.2) + ":" + hex(d.3) \
-            + ":" + hex(d.4) + ":" + hex(d.5) + ":" + hex(d.6) + ":" + hex(d.7)
+        return f"{hex(d.0)}:{hex(d.1)}:{hex(d.2)}:{hex(d.3)}" \
+            + f":{hex(d.4)}:{hex(d.5)}:{hex(d.6)}:{hex(d.7)}"
 
     def __repr__(self):
         return self.__str__() # TODO: Proper repr
@@ -1066,7 +1046,7 @@ class IPv4Network(object):
         self.mask_len = mask_len
 
     def __str__(self) -> str:
-        return str(self.address) + "/" + str(self.mask_len) # TODO: conventional format
+        return f"{self.address}/{self.mask_len}" # TODO: conventional format
 
     def __repr__(self):
         return self.__str__() # TODO: Proper repr
@@ -1103,7 +1083,7 @@ class IPv6Network(object):
         self.mask_len = mask_len
 
     def __str__(self) -> str:
-        return str(self.address) + "/" + str(self.mask_len) # TODO: conventional format
+        return f"{self.address}/{self.mask_len}" # TODO: conventional format
 
     def __repr__(self):
         return self.__str__() # TODO: Proper repr
@@ -1172,12 +1152,12 @@ class DateTime(object):
                 # e.g. "-0:30" as the sign is carried by the 'hour' integer
                 # TODO: Test actual nso behavour
                 if tz_h == 0 and tz_m < 0:
-                    tz = "-" + str(tz_h) + ":" + str(tz_m)
+                    tz = f"-{tz_h}:{tz_m}"
                 else:
-                    tz = str(tz_h) + ":" + str(tz_m)
+                    tz = f"{tz_h}:{tz_m}"
 
-        return to_n_dec_str(self.year, 4) + "-" + to_n_dec_str(self.month, 2) + "-" + to_n_dec_str(self.day, 2) + "T" \
-            + to_n_dec_str(self.hour, 2) + ":" + to_n_dec_str(self.minute, 2) + ":" + to_n_dec_str(self.second, 2) + "." + to_n_dec_str(self.microsecond, 6) \
+        return f"{to_n_dec_str(self.year, 4)}-{to_n_dec_str(self.month, 2)}-{to_n_dec_str(self.day, 2)}T" \
+            + f"{to_n_dec_str(self.hour, 2)}:{to_n_dec_str(self.minute, 2)}:{to_n_dec_str(self.second, 2)}.{to_n_dec_str(self.microsecond, 6)}" \
             + tz
 
     def __repr__(self):
@@ -1347,11 +1327,11 @@ class Date(object):
                 # e.g. "-0:30" as the sign is carried by the 'hour' integer
                 # TODO: Test actual nso behavour
                 if tz_h == 0 and tz_m < 0:
-                    tz = "-" + str(tz_h) + ":" + str(tz_m)
+                    tz = f"-{tz_h}:{tz_m}"
                 else:
-                    tz = str(tz_h) + ":" + str(tz_m)
+                    tz = f"{tz_h}:{tz_m}"
 
-        return to_n_dec_str(self.year, 4) + "-" + to_n_dec_str(self.month, 2) + "-" + to_n_dec_str(self.day, 2) + tz
+        return f"{to_n_dec_str(self.year, 4)}-{to_n_dec_str(self.month, 2)}-{to_n_dec_str(self.day, 2)}{tz}"
 
     def __repr__(self):
         return self.__str__() # TODO: Proper repr
@@ -1493,11 +1473,11 @@ class Time(object):
                 # e.g. "-0:30" as the sign is carried by the 'hour' integer
                 # TODO: Test actual nso behavour
                 if tz_h == 0 and tz_m < 0:
-                    tz = "-" + str(tz_h) + ":" + str(tz_m)
+                    tz = f"-{tz_h}:{tz_m}"
                 else:
-                    tz = str(tz_h) + ":" + str(tz_m)
+                    tz = f"{tz_h}:{tz_m}"
 
-        return to_n_dec_str(self.hour, 2) + ":" + to_n_dec_str(self.minute, 2) + ":" + to_n_dec_str(self.second, 2) + "." + to_n_dec_str(self.microsecond, 6) + tz
+        return f"{to_n_dec_str(self.hour, 2)}:{to_n_dec_str(self.minute, 2)}:{to_n_dec_str(self.second, 2)}.{to_n_dec_str(self.microsecond, 6)}{tz}"
 
     def __repr__(self):
         return self.__str__() # TODO: Proper repr

--- a/telemetrify-core/src/telemetrify/main/common.act
+++ b/telemetrify-core/src/telemetrify/main/common.act
@@ -64,7 +64,7 @@ def state_str(state: int) -> str:
         return "CLOSING"
     elif state == STATE_CLOSED:
         return "CLOSED"
-    raise ValueError("Unknown state value: " + str(state))
+    raise ValueError(f"Unknown state value: {state}")
 
 OUTPUT_STATE_RESET = 0
 OUTPUT_STATE_SYNCED = 2
@@ -80,7 +80,7 @@ def output_state_str(state: int) -> str:
         return "RESET_REMOVAL"
     elif state == OUTPUT_STATE_PENDING_RESET_RECONFIG:
         return "RESET_RECONFIG"
-    raise ValueError("Unknown state value: " + str(state))
+    raise ValueError(f"Unknown state value: {state}")
 
 INVALID_UID = -1
 
@@ -136,7 +136,7 @@ class State(Message):
         self.state = state
 
     def __repr__(self) -> str:
-        return "State(%d, %s)" % (self.sender_uid, state_str(self.state))
+        return f"State({self.sender_uid}, {state_str(self.state)})"
 
 class Resync(Message):
     """"Request a full data (i.e. replace or delete, not delta) update."""
@@ -147,7 +147,7 @@ class Resync(Message):
         self._workaround_actonc_issue_1598 = True # https://github.com/actonlang/acton/issues/1598
 
     def __repr__(self) -> str:
-        return "Resync(%d)" % self.sender_uid
+        return f"Resync({self.sender_uid})"
 
 class Reset(Message):
     """"Request a delete update prior to releasing one or more downstream nodes."""
@@ -158,7 +158,7 @@ class Reset(Message):
         self._workaround_actonc_issue_1598 = True # https://github.com/actonlang/acton/issues/1598
 
     def __repr__(self) -> str:
-        return "Reset(%d)" % self.sender_uid
+        return f"Reset({self.sender_uid})"
 
 class FlowNodeBase(object):
     @property
@@ -669,8 +669,7 @@ class OutputData(object):
         return self.__repr__()
 
     def __repr__(self) -> str:
-        return "OutputData(%s, %s, %s, %s, %s, %s)" % (
-            repr(self.key), repr(self.output), output_state_str(self.state), repr(self.awaited_reset_client_uids), repr(self.pending_config), repr(self._flow_params_merge))
+        return f"OutputData({repr(self.key)}, {repr(self.output)}, {output_state_str(self.state)}, {repr(self.awaited_reset_client_uids)}, {repr(self.pending_config)}, {repr(self._flow_params_merge)})"
 
     @staticmethod
     def create(key: Keypath, output_update: OutputUpdate):
@@ -878,7 +877,7 @@ class OutputUpdate(object):
         self.output = output
 
     def __str__(self) -> str:
-        return "OutputUpdate(" + str(self.config) + ", " + str(self.output) + ")"
+        return f"OutputUpdate({self.config}, {self.output})"
 
     def __repr__(self):
         return self.__str__()
@@ -899,8 +898,8 @@ class SubscriberUpdate(object):
     def __str__(self) -> str:
         s = []
         for output_key, output_update in self.outputs:
-            unsafe_list_append(s, "(" + str(output_key) + ", " + optional_str(output_update, "None") + ")")
-        return "SubscriberUpdate(" + optional_str(self.config, "None") + ", " + optional_str(self.source, "None") + ", " + str(s) + ")"
+            unsafe_list_append(s, f"({output_key}, {optional_str(output_update, 'None')})")
+        return f"SubscriberUpdate({optional_str(self.config, 'None')}, {optional_str(self.source, 'None')}, {s})"
 
     def __repr__(self):
         return self.__str__()

--- a/telemetrify-core/src/telemetrify/main/resource/shared_resources.act
+++ b/telemetrify-core/src/telemetrify/main/resource/shared_resources.act
@@ -94,7 +94,7 @@ actor SharedResources(
     var resources: dict[PTag, SharedResourceData] = {}
 
     def request(tags: set[PTag], response_cb: action(dict[PTag, SharedResource]) -> None):
-        log.debug("request", {"tags": set_str(tags)})
+        log.debug("request", {"tags": str(tags)})
 
         response: dict[PTag, SharedResource] = {}
         for tag in tags:
@@ -112,7 +112,7 @@ actor SharedResources(
                     resources[tag] = new_resource_data
                     response[tag] = resource
 
-        log.debug("request - reply", {"tags": set_str(tags), "response": mapping_str(response)})
+        log.debug("request - reply", {"tags": str(tags), "response": str(response)})
 
         response_cb(response)
 

--- a/telemetrify-core/src/telemetrify/main/source/mock/netconf.act
+++ b/telemetrify-core/src/telemetrify/main/source/mock/netconf.act
@@ -60,7 +60,7 @@ actor MockNetconfSourceAct(
 
     def rpc(content: xml.Node, add_rpc_attrs: list[(str, str)], callback: action(?xml.Node) -> None) -> None:
         if log.output_level >= logging.TRACE:
-            log.trace("SOURCE mock-netconf RPC", {"content": content.encode(), "add_rpc_attrs": list_str(add_rpc_attrs)})
+            log.trace("SOURCE mock-netconf RPC", {"content": content.encode(), "add_rpc_attrs": str(add_rpc_attrs)})
 
         reply_inner: list[xml.Node] = []
 
@@ -383,12 +383,12 @@ actor MockNetconfSourceAct(
             y = p // pplc
             z = p % pplc
             subints = min([total_interfaces - i, max_subints])
-            pintf = "xe-%d/%d/%d" % (x, y, z)
+            pintf = f"xe-{x}/{y}/{z}"
             pintf_index = intf_index
             intf_index += 1
             subint_items: list[(str, int)] = []
             for j in range(subints):
-                lintf = "xe-%d/%d/%d.%d" % (x, y, z, j)
+                lintf = f"xe-{x}/{y}/{z}.{j}"
                 subint_items.append((lintf, intf_index))
                 intf_index += 1
             res.append((pintf, pintf_index, subint_items))

--- a/telemetrify-core/src/telemetrify/main/source/mock/netconf_replay.act
+++ b/telemetrify-core/src/telemetrify/main/source/mock/netconf_replay.act
@@ -71,7 +71,7 @@ actor MockNetconfReplaySourceAct(
 
     def rpc(content: xml.Node, add_rpc_attrs: list[(str, str)], callback: action(?xml.Node) -> None) -> None:
         if log.output_level >= logging.TRACE:
-            log.trace("SOURCE mock-netconf-replay RPC", {"content": content.encode(), "add_rpc_attrs": list_str(add_rpc_attrs)})
+            log.trace("SOURCE mock-netconf-replay RPC", {"content": content.encode(), "add_rpc_attrs": str(add_rpc_attrs)})
 
         last_reply: xml.Node = current_reply
 

--- a/telemetrify-core/src/telemetrify/main/test/common.act
+++ b/telemetrify-core/src/telemetrify/main/test/common.act
@@ -68,7 +68,7 @@ class EventTester(object):
                 else:
                     self.report_result(True, None)
             else:
-                self.report_result(False, AssertionError("Expected events: " + list_str(self._expected_events) + " actual events: " + list_str(self._actual_events)))
+                self.report_result(False, AssertionError(f"Expected events: {self._expected_events} actual events: {self._actual_events}"))
 
     def expect(self, events: list[str], next_step: ?action() -> None):
         self._expected_events.extend(events)

--- a/telemetrify-core/src/telemetrify/nso/subscriber.act
+++ b/telemetrify-core/src/telemetrify/nso/subscriber.act
@@ -44,7 +44,7 @@ class SubscriptionSpec(object):
         self.is_required = is_required
 
     def __str__(self) -> str:
-        return "SubscriptionSpec(" + str(self.identity) + ", is_required=" + str(self.is_required) + ")"
+        return f"SubscriptionSpec({self.identity}, is_required={self.is_required})"
 
     def __repr__(self):
         return self.__str__()
@@ -60,7 +60,7 @@ class SubscriptionIdentity(object):
         self.sub_type = sub_type
 
     def __str__(self) -> str:
-        return "SubscriptionIdentity(" + str(self.path) + ", " + sub_type_str(self.sub_type) + ")"
+        return f"SubscriptionIdentity({self.path}, {sub_type_str(self.sub_type)})"
 
     def __repr__(self):
         return self.__str__()
@@ -236,7 +236,7 @@ def make_base_path(subscription_specs: list[SubscriptionSpec], base_path: ?Keypa
 
         if base_path is not None:
             if not base_path.is_sub_path(common_path):
-                raise ValueError("Subscriptions: " + list_str(subscription_specs) + " are not decendents of base_path: " + str(base_path))
+                raise ValueError(f"Subscriptions: {subscription_specs} are not decendents of base_path: {base_path}")
             return base_path
         else:
             return common_path
@@ -263,7 +263,7 @@ class MirrorRefiner(Refiner):
             for sub_keypath in sub_keypaths:
                 _keypath = sub_keypath.get_slice(0, self.num_keys)
                 if len(_keypath) != self.num_keys:
-                    raise Exception("Broken invariant: MirrorRefiner received less than expected number of keys in updated keypath:" + str(len(_keypath)) + " != " + str(self.num_keys))
+                    raise Exception(f"Broken invariant: MirrorRefiner received less than expected number of keys in updated keypath:{len(_keypath)} != {self.num_keys}")
                 keypaths.add(_keypath)
 
         for keypath in keypaths:
@@ -355,7 +355,7 @@ class SubscriptionParams(object):
         self.ancestor_delete_fallback_origin = ancestor_delete_fallback_origin
 
     def __str__(self) -> str:
-        return "SubscriptionParams(" + str(self.identity) + ", " + optional_str(self.ancestor_delete_fallback_origin, "None") + ")"
+        return f"SubscriptionParams({self.identity}, {optional_str(self.ancestor_delete_fallback_origin, 'None')})"
 
     def __repr__(self):
         return self.__str__()
@@ -451,7 +451,7 @@ actor CdbCache(cdb_sub_conn: CdbConnection,
                 merge_root = etagvals_to_merge_ttree(etvs, Cursor(_schema))
             except Exception as exc:
                 log.trace("Error converting subscription event etagvals", {"sub_id": sub_id, "etvs": etvs})
-                on_error(Exception("Get modifications to tnode conversion error: " + str(exc)))
+                on_error(Exception(f"Get modifications to tnode conversion error: {exc}"))
             else:
                 log.trace("Got subscription event merge root", {"sub_id": sub_id, "ttree": merge_root})
                 # Filter irrelevant parts of is-delete-only-sub
@@ -533,10 +533,10 @@ actor CdbCache(cdb_sub_conn: CdbConnection,
             _do_get_modifications()
         elif isinstance(v, Exception):
             log.error("Sub event error", {"msg": v.error_message})
-            on_error(Exception("Sub event error: " + str(v)))
+            on_error(Exception(f"Sub event error: {v}"))
         else:
             log.error("Sub event error", {"msg": v})
-            on_error(Exception("Sub event error: " + str(v)))
+            on_error(Exception(f"Sub event error: {v}"))
 
     def _do_get_modifications():
         #if _pending_sub_ids:
@@ -556,14 +556,14 @@ actor CdbCache(cdb_sub_conn: CdbConnection,
             _do_get_modifications()
         elif isinstance(v, Exception):
             log.error("Get modifications error", {"sub_id": sub_id, "exc": v})
-            on_error(Exception("Get modifications exception: " + str(v)))
+            on_error(Exception(f"Get modifications exception: {v}"))
         else:
             log.error("Get modifications error", {"sub_id": sub_id, "msg": v})
-            on_error(Exception("Get modifications error: " + str(v)))
+            on_error(Exception(f"Get modifications error: {v}"))
 
     def _on_sync_subscription_socket(c: CdbConnection, v: ?Exception):
         if v is not None:
-            on_error(Exception("Sub sync error: " + str(v)))
+            on_error(Exception(f"Sub sync error: {v}"))
         update()
 
     def _on_subscription_success(sub_ids: dict[SubscriptionIdentity, int]) -> None:

--- a/telemetrify-core/src/telemetrify/nsoapi/conf.act
+++ b/telemetrify-core/src/telemetrify/nsoapi/conf.act
@@ -154,7 +154,7 @@ class EKeypath:
         self.elems = elems
 
     def __str__(self) -> str:
-        return "EKeypath(" + list_str(self.elems) + ")"
+        return f"EKeypath({self.elems})"
 
     def __repr__(self):
         return self.__str__()

--- a/telemetrify-core/src/telemetrify/nsoapi/proto.act
+++ b/telemetrify-core/src/telemetrify/nsoapi/proto.act
@@ -48,6 +48,7 @@ CDB_ERROR_FLAG_MASK = CDB_REL_FLAG_MASK
 _ERL_EXTERN_FMT = Version
 
 class ProtoError(Exception):
+    msg: str
     def __init__(self):
         pass
 
@@ -60,7 +61,7 @@ class MaapiProtoError(ProtoError):
         self.msg = msg
 
     def __str__(self) -> str:
-        return "MaapiProtoError(\"" + self.msg + "\")"
+        return f'MaapiProtoError("{self.msg}")'
 
     def __repr__(self):
         return self.__str__()
@@ -387,7 +388,7 @@ class BufferReader(object):
             size = self.read_u8()
             if isinstance(size, int):
                 if size > 8:
-                    return ValueError("Invalid SmallBig `int` size: " + str(size))
+                    return ValueError(f"Invalid SmallBig `int` size: {size}")
                 sign = self.read_u8()
                 if isinstance(sign, int):
                     b = self.read_bytes(size)
@@ -407,7 +408,7 @@ class BufferReader(object):
             else:
                 return size
         else:
-            return ValueError("Invalid `int` tag: " + str(tag))
+            return ValueError(f"Invalid `int` tag: {tag}")
 
     def read_atom(self, tag: int) -> value: # (str | IncompleteReadError)
         # if tag == Version:
@@ -489,7 +490,7 @@ class BufferReader(object):
         elif tag == LargeTuple:
             return self.read_u32_be()
         else:
-            return ValueError("Invalid `tuple` tag: " + str(tag))
+            return ValueError(f"Invalid `tuple` tag: {tag}")
 
     def read_list_size(self, tag: int) -> value: # (int | IncompleteReadError | ValueError)
         # if tag == Version:
@@ -520,7 +521,7 @@ class BufferReader(object):
         elif tag == List:
             return self.read_u32_be()
         else:
-            return ValueError("Invalid `list` tag: " + str(tag))
+            return ValueError(f"Invalid `list` tag: {tag}")
 
 class EObject:
     def __init__(self):
@@ -580,7 +581,7 @@ class EObject:
 
             # if tag == Compressed:
 
-            return ValueError("Invalid `EObject` tag: " + str(tag))
+            return ValueError(f"Invalid `EObject` tag: {tag}")
         return tag
 
 class EList(EObject):
@@ -599,10 +600,10 @@ class EList(EObject):
         for e in self.elems:
             #sl.append(str(e))
             unsafe_list_append(sl, str(e))
-        return "[" + ", ".join(sl) + "]"
+        return f"[{', '.join(sl)}]"
 
     def __repr__(self):
-        return "EList(" + repr(self.elems) + ", " + repr(self.is_proper) + ")"
+        return f"EList({repr(self.elems)}, {repr(self.is_proper)})"
 
     def encode(self, writer):
         size = len(self.elems)
@@ -680,10 +681,10 @@ class ETuple(EObject):
         for e in self.elems:
             #sl.append(str(e))
             unsafe_list_append(sl, str(e))
-        return "(" + ", ".join(sl) + ")"
+        return f"({', '.join(sl)})"
 
     def __repr__(self):
-        return "ETuple(" + repr(self.elems) + ")"
+        return f"ETuple({repr(self.elems)})"
 
     def encode(self, writer: BufferWriter):
         size: int = len(self.elems)
@@ -747,7 +748,7 @@ class EBinary(EObject):
         return self.data.decode()
 
     def __repr__(self):
-        return "EBinary(" + self.__str__() + ")"
+        return f"EBinary({self.__str__()})"
 
     @staticmethod
     def from_str(s: str):
@@ -774,7 +775,7 @@ class EAtom(EObject):
         return self.val
 
     def __repr__(self):
-        return "EAtom('" + self.__str__() + "')"
+        return f"EAtom('{self.__str__()}')"
 
     @staticmethod
     def from_bool(b: bool):
@@ -814,7 +815,7 @@ class EInt(EObject):
         return self.val.__str__()
 
     def __repr__(self):
-        return "EInt(" + self.__str__() + ")"
+        return f"EInt({self.__str__()})"
 
     def encode(self, writer):
         writer.write_int(self.val)
@@ -837,7 +838,7 @@ class EString(EObject):
         return self.data.decode()
 
     def __repr__(self):
-        return "EString(\"" + self.__str__() + "\")"
+        return f'EString("{self.__str__()}")'
 
     @staticmethod
     def from_str(s: str):
@@ -905,11 +906,7 @@ class ConfResponse(object):
         _error_msg: ?str = self.error_msg
         if _error_msg is not None:
             error_msg = _error_msg
-        return "ConfResponse(op=" + self.op.__str__() \
-            + ", term=" + term_str \
-            + ", err=" + str(self.is_error) \
-            + ", errcode=" + str(self.error_code) \
-            + ", errstr=" + error_msg + ")"
+        return f"ConfResponse(op={self.op}, term={term_str}, err={self.is_error}, errcode={self.error_code}, errstr={error_msg})"
 
     def __repr__(self):
         return self.__str__()

--- a/telemetrify-core/src/telemetrify/nsoapi/schema.act
+++ b/telemetrify-core/src/telemetrify/nsoapi/schema.act
@@ -73,7 +73,7 @@ class TypeId:
         self.name = name
 
     def __str__(self) -> str:
-        return str(self.ns_hash) + ":" + self.name
+        return f"{self.ns_hash}:{self.name}"
 
     def __repr__(self):
         return self.__str__() # TODO: Proper repr
@@ -81,11 +81,11 @@ class TypeId:
     def str_pretty(self, hash_to_name: dict[int, str]) -> str:
         cns = try_get(hash_to_name, self.ns_hash)
         if cns is not None:
-            return cns + ":" + self.name
+            return f"{cns}:{self.name}"
         return self.__str__()
 
     def prsrc(self):
-        return "TypeId(" + str(self.ns_hash) + ", \"" + self.name + "\")"
+        return f'TypeId({self.ns_hash}, "{self.name}")'
 
 extension TypeId(Hashable):
     def __eq__(self, other) -> bool:
@@ -116,7 +116,7 @@ class SchemaPath(object):
         return "".join(l)
 
     def __repr__(self) -> str:
-        return "SchemaPath(%s, %s)" % (list_repr(self.tags), list_optional_repr(self.mount_ids))
+        return f"SchemaPath({list_repr(self.tags)}, {list_optional_repr(self.mount_ids)})"
 
     def to_keypath(self) -> Keypath:
         l: list[Id] = []
@@ -188,7 +188,7 @@ class Schema:
         src_str += "roots: dict[HTag, Node] = {"
         for tag in self._root.children.keys():
             src_str += str(tag)
-            src_str += ": nodes_%d_%d, " % (tag.ns_hash, tag.name_hash)
+            src_str += f": nodes_{tag.ns_hash}_{tag.name_hash}, "
         src_str += "}\n"
         src_str += "nshash_to_namespace: dict[int, NamespaceDescription] = {"
         for nshash, ns in self._nshash_to_namespace.items():
@@ -205,8 +205,8 @@ class Schema:
             src_str += ns.prsrc()
             src_str += ", "
         src_str += "}\n"
-        src_str += "hash_to_name: dict[int, str] = %s\n" % str(self._hash_to_name)
-        src_str += "name_to_hash: dict[str, int] = %s\n" % str(self._name_to_hash)
+        src_str += f"hash_to_name: dict[int, str] = {self._hash_to_name}\n"
+        src_str += f"name_to_hash: dict[str, int] = {self._name_to_hash}\n"
         src_str += "mount_id_maps: dict[HTag, NamespaceMaps] = {"
         for tag, nsmaps in self._mount_id_maps.items():
             src_str += str(tag)
@@ -613,8 +613,8 @@ class NamespaceDescription:
 
     def __str__(self) -> str:
         return "NamespaceDescription(" \
-            + self.cns + "," + self.ns + "," + self.prefix + "," + str(self.ns_hash) + "," \
-            + optional_str(self.revision, "") + "," + self.module + ")"
+            + f"{self.cns},{self.ns},{self.prefix},{self.ns_hash}," \
+            + f"{optional_str(self.revision, '')},{self.module})"
 
     def __repr__(self):
         return self.__str__()
@@ -624,11 +624,10 @@ class NamespaceDescription:
         revision = self.revision
 
         if revision is not None:
-            revision_str = "\"" + revision + "\""
+            revision_str = f'"{revision}"'
 
-        return "NamespaceDescription(\"" \
-            + self.cns + "\",\"" + self.ns + "\",\"" + self.prefix + "\"," + str(self.ns_hash) + "," \
-            + revision_str + ",\"" + self.module + "\")"
+        return f'NamespaceDescription("{self.cns}","{self.ns}","{self.prefix}",{self.ns_hash},' \
+            + f'{revision_str},"{self.module}")'
 
     @staticmethod
     def from_ns_tuple(elems: list[EObject]) -> ?NamespaceDescription:
@@ -869,31 +868,31 @@ class Node(object):
         value_type = self.value_type
         if value_type is not None:
             if not value_type.type_id in types:
-                src_str = src_str + value_type.prsrc(types)
-            type_str = "types_%d_%s" % (value_type.type_id.ns_hash, value_type.type_id.name.replace('-', '_').replace('.', 'dot'))
+                src_str = f"{src_str}{value_type.prsrc(types)}"
+            type_str = f"types_{value_type.type_id.ns_hash}_{value_type.type_id.name.replace('-', '_').replace('.', 'dot')}"
 
         children_str = "{"
         for tag, child in self.children.items():
             src_str += child.prsrc(nodes, types)
             children_str += str(tag)
             children_str += ": "
-            children_str += "nodes_%d_%d, " % (child.tag.ns_hash, child.tag.name_hash)
+            children_str += f"nodes_{child.tag.ns_hash}_{child.tag.name_hash}, "
         children_str += "}"
 
         keys_str = "["
         for key in self.keys:
-            keys_str += "nodes_%d_%d, " % (key.tag.ns_hash, key.tag.name_hash)
+            keys_str += f"nodes_{key.tag.ns_hash}_{key.tag.name_hash}, "
         keys_str += "]"
 
-        src_str += "nodes_%d_%d" % (self.tag.ns_hash, self.tag.name_hash)
-        src_str += " = Node(" + str(self.tag) + ", "
-        src_str += str(self.min_occurs) + ", "
-        src_str += str(self.max_occurs) + ", "
-        src_str += str(self.flags) + ", "
-        src_str += str(self.conf_type) + ", "
-        src_str += type_str + ", "
-        src_str += keys_str + ", "
-        src_str += children_str + ")\n"
+        src_str += f"nodes_{self.tag.ns_hash}_{self.tag.name_hash}"
+        src_str += f" = Node({self.tag}, "
+        src_str += f"{self.min_occurs}, "
+        src_str += f"{self.max_occurs}, "
+        src_str += f"{self.flags}, "
+        src_str += f"{self.conf_type}, "
+        src_str += f"{type_str}, "
+        src_str += f"{keys_str}, "
+        src_str += f"{children_str})\n"
 
         return src_str
 
@@ -959,7 +958,7 @@ class Type(object):
         self.conf_type = conf_type
 
     def __str__(self) -> str:
-        return "Type(" + self.__str_common() + ")"
+        return f"Type({self.__str_common()})"
 
     def __repr__(self):
         return self.__str__()
@@ -969,8 +968,8 @@ class Type(object):
         _parent_type = self.parent_type
         if _parent_type is not None:
             parent_type_id = str(_parent_type.type_id)
-        return str(self.type_id) + ", " + parent_type_id \
-            + ", " + optional_str(self.conf_type, "None")
+        return f"{self.type_id}, {parent_type_id}" \
+            + f", {optional_str(self.conf_type, 'None')}"
 
     def prsrc(self, types: dict[TypeId, Type]) -> str:
         src_str = ""
@@ -980,10 +979,10 @@ class Type(object):
         parent = self.parent_type
         if parent is not None:
             if parent.type_id not in types:
-                src_str = src_str + parent.prsrc(types)
+                src_str = f"{src_str}{parent.prsrc(types)}"
                 types[parent.type_id] = parent
 
-            parent_str = "types_%d_%s" % (parent.type_id.ns_hash, parent.type_id.name.replace('-', '_').replace('.', 'dot'))
+            parent_str = f"types_{parent.type_id.ns_hash}_{parent.type_id.name.replace('-', '_').replace('.', 'dot')}"
 
         conf_type = self.conf_type
         if conf_type is not None:
@@ -991,7 +990,7 @@ class Type(object):
         else:
             conf_str = "None"
 
-        src_str = src_str + "types_%d_%s" % (self.type_id.ns_hash, self.type_id.name.replace('-', '_').replace('.', 'dot')) + " = Type(" + self.type_id.prsrc() + ", " + parent_str + ", " + conf_str + ")\n"
+        src_str = f"{src_str}types_{self.type_id.ns_hash}_{self.type_id.name.replace('-', '_').replace('.', 'dot')} = Type({self.type_id.prsrc()}, {parent_str}, {conf_str})\n"
 
         return src_str
 
@@ -1130,7 +1129,7 @@ class EnumType(Type):
         self.ordinal_to_name = _ordinal_to_name
 
     def __str__(self) -> str:
-        return "EnumType(" + self.__str_common() + ", " + str(self.name_to_ordinal) + ")"
+        return f"EnumType({self.__str_common()}, {self.name_to_ordinal})"
 
     def __repr__(self):
         return self.__str__()
@@ -1203,7 +1202,7 @@ class UnionType(Type):
         self.types = types
 
     def __str__(self) -> str:
-        return "UnionType(" + self.__str_common() + ", " + list_str(self.types) + ")"
+        return f"UnionType({self.__str_common()}, {self.types})"
 
     def __repr__(self):
         return self.__str__()
@@ -1269,7 +1268,7 @@ class RestrictedNumberType(Type):
         self.ranges = ranges
 
     def __str__(self) -> str:
-        return "RestrictedNumberType(" + self.__str_common() + ")"
+        return f"RestrictedNumberType({self.__str_common()})"
 
     def __repr__(self):
         return self.__str__()
@@ -1297,7 +1296,7 @@ class BitsType(Type):
         self.name_to_pos = _name_to_pos
 
     def __str__(self) -> str:
-        return "BitsType(" + self.__str_common() + ")"
+        return f"BitsType({self.__str_common()})"
 
     def __repr__(self):
         return self.__str__()
@@ -1415,7 +1414,7 @@ class Decimal64Type(Type):
         self.ranges = ranges
 
     def __str__(self) -> str:
-        return "Decimal64Type(" + self.__str_common() + ")"
+        return f"Decimal64Type({self.__str_common()})"
 
     def __repr__(self):
         return self.__str__()
@@ -1450,7 +1449,7 @@ class ListType(Type):
         self.elem_type = elem_type
 
     def __str__(self) -> str:
-        return "ListType(" + self.__str_common() + ", " + str(self.elem_type) + ")"
+        return f"ListType({self.__str_common()}, {self.elem_type})"
 
     def __repr__(self):
         return self.__str__()
@@ -1534,7 +1533,7 @@ class ListRestrictionType(Type):
         self.ranges = ranges
 
     def __str__(self) -> str:
-        return "ListRestrictionType(" + self.__str_common() + ")"
+        return f"ListRestrictionType({self.__str_common()})"
 
     def __repr__(self):
         return self.__str__()
@@ -1555,7 +1554,7 @@ class DisplayHintType(Type):
         self.conf_type = None
 
     def __str__(self) -> str:
-        return "DisplayHintType(" + self.__str_common() + ")"
+        return f"DisplayHintType({self.__str_common()})"
 
     def __repr__(self):
         return self.__str__()

--- a/telemetrify-core/src/telemetrify/test.act
+++ b/telemetrify-core/src/telemetrify/test.act
@@ -40,7 +40,7 @@ from telemetrify.main.config import *
 _OPT_RECORD_TO = '--record-to'
 
 _OPTS_HELP: dict[str, str] = {
-    _OPT_RECORD_TO: _OPT_RECORD_TO + " <filename>",
+    _OPT_RECORD_TO: f"{_OPT_RECORD_TO} <filename>",
 }
 
 class Opts(object):
@@ -127,7 +127,7 @@ actor main(env):
     path: str = args[0]
 
     def print_help_and_exit():
-        print("usage:", path.split("/", -1)[-1], "[ " + " | ".join(tests.keys()) + " ] [ " + " | ".join(_OPTS_HELP.values()) + " ]")
+        print("usage:", path.split("/", -1)[-1], f"[ {' | '.join(tests.keys())} ] [ {' | '.join(_OPTS_HELP.values())} ]")
         await async env.exit(1)
 
     if len(args) >= 2:
@@ -387,7 +387,7 @@ actor test_writer(env: Env, opts: Opts):
             schema = unsafe_get_shared_schema(shared_schema)
 
             for _name, _hash in schema._name_to_hash.items():
-                print(_name + " : " + str(_hash))
+                print(f"{_name} : {_hash}")
 
             c.start_trans(DB_RUNNING, MODE_READ_WRITE, UserIdentity(None, None, None, None), lambda c, t: _on_start_trans(c, shared_schema, t))
         else:
@@ -459,16 +459,16 @@ actor test_tsdb_writer(env: Env, opts: Opts):
     log = logging.Logger(log_handler)
 
     def _on_connect_error(e):
-        log.error("MAAPI connect failed:" + str(e), None)
+        log.error(f"MAAPI connect failed:{e}", None)
 
     def _on_connect(c):
-        log.info("Current time:" + str(time.now()), None)
+        log.info(f"Current time:{time.now()}", None)
         log.info("MAAPI connected!!!!", None)
         c.start_user_session(UserSessionDescription("admin", "127.0.0.1", "system", [], None, False, UserIdentity(None, None, None, None)), _on_user_session)
 
     def _on_user_session(c, e):
         if e is None:
-            log.info("Current time:" + str(time.now()), None)
+            log.info(f"Current time:{time.now()}", None)
             log.info("MAAPI user session started!!!!", None)
             c.load_schema(_on_load_schema)
         else:
@@ -478,12 +478,12 @@ actor test_tsdb_writer(env: Env, opts: Opts):
     def _on_load_schema(c, e, shared_schema):
         if e is None and shared_schema is not None:
             schema: Schema = unsafe_get_shared_schema(shared_schema)
-            log.info("Current time:" + str(time.now()), None)
+            log.info(f"Current time:{time.now()}", None)
             log.info("MAAPI loaded schema!!!!", None)
             log.debug("", {"schema": schema})
 
             for _name, _hash in schema._name_to_hash.items():
-                log.debug(_name + " : " + str(_hash), None)
+                log.debug(f"{_name} : {_hash}", None)
 
             log.info("Starting TSDB client", None)
             tsdb_sess = tsdb.m3.Client(net.TCPConnectCap(net.TCPCap(net.NetCap(env.auth))), "m3db", 7201, lambda c: _on_tsdb_connect(c, shared_schema), _on_tsdb_error, log_handler)
@@ -496,7 +496,7 @@ actor test_tsdb_writer(env: Env, opts: Opts):
             await async env.exit(1)
 
     def _on_nc_error(c, e):
-        log.error("NETCONF client failed:" + str(e), None)
+        log.error(f"NETCONF client failed:{e}", None)
         await async env.exit(1)
 
     def dumb_push(cursor, name):
@@ -532,7 +532,7 @@ actor test_tsdb_writer(env: Env, opts: Opts):
         vmx_sess = telemetrify.net.netconf.Client(env.auth, "vmx", 830, "vrnetlab", "VR-netlab9", None, lambda c: _on_vmx_connect(c, shared_schema, writer), _on_nc_error, None, None)
 
     def _on_tsdb_error(c, e):
-        log.error("TSDB client failed: " + str(e), None)
+        log.error(f"TSDB client failed: {e}", None)
         await async env.exit(1)
 
     def _on_vmx_connect(c, shared_schema, writer):
@@ -892,7 +892,7 @@ class DeviceSettingsRefiner(Refiner):
                             dict_set_discard(self._authgroup_devices, authgroup_keys, device_keys)
                     updated.add(device_keys)
 
-        #print("UPDATED: " + list_str(list(iter(updated))))
+        #print(f"UPDATED: {list(iter(updated))}")
 
         return list(iter(updated))
 

--- a/telemetrify-core/src/telemetrify/vmanage/test_vmanage.act
+++ b/telemetrify-core/src/telemetrify/vmanage/test_vmanage.act
@@ -183,7 +183,7 @@ def _haversine_distance(lat1: float, lon1: float, lat2: float, lon2: float) -> f
 
 class _Session(object):
     def __init__(self, s1: _Loc, s2: _Loc):
-        self.name = "%s-%s" % (s1.name, s2.name)
+        self.name = f"{s1.name}-{s2.name}"
         self.s1 = s1
         self.s2 = s2
         self.distance = _haversine_distance(s1.latitude, s1.longitude, s2.latitude, s2.longitude)
@@ -256,7 +256,7 @@ class _MockAppRoute(object):
 #                "vip_idx": 394,
 #                "dst_port": 12407,
                 # TODO: should be using IP address, not name here
-                "name": sess.s1.code + ":public-internet-" + sess.s2.code + ":public-internet",
+                "name": f"{sess.s1.code}:public-internet-{sess.s2.code}:public-internet",
 #                "sla_class_list": "0",
 #                "tunnel_color": "public-internet:public-internet",
 #                "host_name": sess.s1.country.lower() + "-foo-" + sess.s1.code.lower() + "-1"

--- a/telemetrify-core/src/tsdb/m3.act
+++ b/telemetrify-core/src/tsdb/m3.act
@@ -40,7 +40,7 @@ actor Client(auth: net.TCPConnectCap, address: str, port: int, on_connect: actio
 
     def quick_init(on_response: action(Client, bool) -> None):
         def _on_response(client: tsdb.http.Client, response: tsdb.http.Response):
-            log.debug("HTTP response status: " + str(response.status), None)
+            log.debug(f"HTTP response status: {response.status}", None)
             log.trace(response.body.decode(), None)
 
             def _post_ready(timeout):
@@ -48,7 +48,7 @@ actor Client(auth: net.TCPConnectCap, address: str, port: int, on_connect: actio
                 http_client.post("/api/v1/services/m3db/namespace/ready", json.encode(json_dict).encode(), lambda c, r: _on_ready_response(c, r, timeout))
 
             def _on_ready_response(client: tsdb.http.Client, response: tsdb.http.Response, timeout: int):
-                log.trace("Namespace ready request:" + response.body.decode(), None)
+                log.trace(f"Namespace ready request:{response.body.decode()}", None)
 
                 if response.status != 200 and timeout > 0:
                     after 1: _post_ready(timeout - 1)
@@ -72,7 +72,7 @@ actor Client(auth: net.TCPConnectCap, address: str, port: int, on_connect: actio
         json_dict["timestamp"] = str(metric.timestamp)
 
         def _on_response(client: tsdb.http.Client, response: tsdb.http.Response):
-            log.debug("HTTP response status: " + str(response.status), None)
+            log.debug(f"HTTP response status: {response.status}", None)
             log.trace(response.body.decode(), None)
             await async on_response(self, response.status == 200)
 

--- a/telemetrify-nso/telemetrify-nid-addon/packages/telemetrify/src/acton/telemetrify-ext/src/telemetrify_ext/resource/l3vpn_svc.act
+++ b/telemetrify-nso/telemetrify-nid-addon/packages/telemetrify/src/acton/telemetrify-ext/src/telemetrify_ext/resource/l3vpn_svc.act
@@ -92,7 +92,7 @@ actor L3vpnSvcTrackerActor(shared_resources: SharedResources, log_handler: loggi
             if params is not None:
                 result[ipv4_address] = params
 
-        log.debug("found ", {"result": mapping_str(result)})
+        log.debug("found ", {"result": str(result)})
 
         result_cb(result)
 
@@ -112,7 +112,7 @@ actor L3vpnSvcTrackerActor(shared_resources: SharedResources, log_handler: loggi
             if params is not None:
                 ipv4_address_result[ipv4_address] = params
 
-        log.debug("found ", {"hostnames": mapping_str(hostname_result), "ipv4_addresses": mapping_str(ipv4_address_result)})
+        log.debug("found ", {"hostnames": str(hostname_result), "ipv4_addresses": str(ipv4_address_result)})
 
         result_cb(hostname_result, ipv4_address_result)
 

--- a/telemetrify-nso/telemetrify-nid-addon/packages/telemetrify/src/acton/telemetrify-ext/src/telemetrify_ext/transform/cat8k.act
+++ b/telemetrify-nso/telemetrify-nid-addon/packages/telemetrify/src/acton/telemetrify-ext/src/telemetrify_ext/transform/cat8k.act
@@ -235,7 +235,7 @@ actor IpSlaTransform(
 
     def _on_lookup_result(hostnames_lookup: dict[str, L3vpnSvcParams], ipv4_addresses_lookup: dict[IPv4Address, L3vpnSvcParams], task_id: int):
 
-        log.debug("lookup", {"hostnames": mapping_str(hostnames_lookup), "ipv4_addresses": mapping_str(ipv4_addresses_lookup)})
+        log.debug("lookup", {"hostnames": str(hostnames_lookup), "ipv4_addresses": str(ipv4_addresses_lookup)})
 
         try:
             sender_uid, _ip_sla_stats, flow_params = tasks.pop(task_id)

--- a/telemetrify-nso/telemetrify-nid-addon/packages/telemetrify/src/acton/telemetrify-ext/src/telemetrify_ext/transform/vmanage.act
+++ b/telemetrify-nso/telemetrify-nid-addon/packages/telemetrify/src/acton/telemetrify-ext/src/telemetrify_ext/transform/vmanage.act
@@ -121,7 +121,7 @@ actor VmanageTransform(
 
     def _on_lookup_result(params_lookup: dict[IPv4Address, L3vpnSvcParams], task_id: int):
 
-        log.debug("lookup", {"result": mapping_str(params_lookup)})
+        log.debug("lookup", {"result": str(params_lookup)})
 
         try:
             sender_uid, approutes, flow_params = tasks.pop(task_id)


### PR DESCRIPTION
Replace string concatenation patterns with f-strings and remove the obsolete helper functions mapping_str(), list_str(), and set_str() which are now redundant with built-in str().